### PR TITLE
# fix: replace sentry-spring-boot-starter-jakarta with sentry-spring-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
 		<!-- Sentry error tracking -->
 		<dependency>
 			<groupId>io.sentry</groupId>
-			<artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-			<version>8.34.1</version>
+			<artifactId>sentry-spring-boot-4</artifactId>
+			<version>8.38.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -2,9 +2,6 @@ spring:
   application:
     name: auth-service
 
-  autoconfigure:
-    exclude: io.sentry.spring.boot.jakarta.SentryAutoConfiguration
-
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
…boot-4 for Spring Boot 4.0 compatibility

  sentry-spring-boot-starter-jakarta:8.34.1 targets Spring Boot 3 and references RestClientAutoConfiguration which was removed in Spring Boot 4.0's autoconfiguration restructuring. This caused a ClassNotFoundException
  at bean-name generation on startup, crash-looping the service.

  Replaced with io.sentry:sentry-spring-boot-4:8.38.0 (Sentry's official Spring Boot 4 artifact). Removed the now-stale spring.autoconfigure.exclude in test YAML — the class no longer exists on the classpath and Spring Boot
  would throw on an unknown exclusion. Tests use sentry.enabled: false instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded error tracking and monitoring service dependency to version 8.38.0 to provide enhanced framework compatibility, improved stability, and better overall reliability of error reporting functionality.
  * Removed obsolete auto-configuration exclusion settings from the application configuration, enabling the monitoring service to initialize automatically and reducing unnecessary manual configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->