### PR TITLE
# fix: add flyway baseline-on-migrate for existing schema without his…

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -41,6 +41,31 @@ Current migrations:
 
 **Never edit or delete existing `V*.sql` migration files.** Flyway checksums will fail.
 
+### Deploying onto an existing schema without a Flyway history table
+
+If the database already has tables (e.g., migrated from a pre-Flyway setup or the history table was accidentally dropped) Flyway will refuse to start with:
+
+```
+Found non-empty schema(s) "public" but no schema history table.
+```
+
+Set the following env vars in the K8s Secret or ConfigMap **for the first rollout only**, then remove them once the pod is healthy:
+
+```bash
+FLYWAY_BASELINE_ON_MIGRATE=true
+FLYWAY_BASELINE_VERSION=4   # current highest migration; update if newer migrations exist
+```
+
+After the pod starts successfully, verify the history table was created:
+
+```bash
+kubectl exec -n apps deploy/auth-service -- \
+  sh -c 'PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -U $DB_USERNAME -d homelabdb \
+  -c "SELECT version, description, success FROM flyway_schema_history_auth ORDER BY installed_rank;"'
+```
+
+Then remove `FLYWAY_BASELINE_ON_MIGRATE` from the deployment. Leaving `true` permanently would silently re-baseline if the history table is ever dropped instead of failing loudly.
+
 ---
 
 ## Adding a New OIDC Client
@@ -253,7 +278,10 @@ The K8s deployment uses image tag `:<git-sha>` (not `:latest`). Update `k8s/depl
 kubectl logs -n apps deployment/auth-service | grep -i "flyway\|migration\|error"
 ```
 
-Common causes: database unreachable, migration checksum mismatch (edited existing migration file).
+Common causes:
+- **Database unreachable** — check `DB_URL` env var and PostgreSQL pod status
+- **Checksum mismatch** — an existing `V*.sql` file was edited; restore the original or repair with `flyway repair`
+- **Non-empty schema, no history table** — see *Deploying onto an existing schema without a Flyway history table* above
 
 ### Service fails to start — RSA key error
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,8 +15,8 @@ spring:
   flyway:
     enabled: true
     table: flyway_schema_history_auth
-    baseline-on-migrate: true
-    baseline-version: 4
+    baseline-on-migrate: ${FLYWAY_BASELINE_ON_MIGRATE:false}
+    baseline-version: ${FLYWAY_BASELINE_VERSION:4}
 
 server:
   port: 8080

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,8 @@ spring:
   flyway:
     enabled: true
     table: flyway_schema_history_auth
+    baseline-on-migrate: true
+    baseline-version: 4
 
 server:
   port: 8080


### PR DESCRIPTION
…tory table

  The production database has the public schema populated (V1-V4 applied) but flyway_schema_history_auth was never created, causing startup failure. baseline-on-migrate=true + baseline-version=4 lets Flyway initialize the history table without re-running already-applied migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration configuration for improved initialization handling.

**Note:** This is an internal infrastructure update with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->