### PR TITLE
feat: add device-service OAuth2 client configuration & concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: doemefu/homelab-auth-service
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '37 15 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -65,7 +65,8 @@ Simplest approach (homelab): prefix with `{noop}` so the secret is matched as-is
 ```bash
 kubectl create secret generic homelab-auth-secrets -n apps \
   --from-literal=grafana-client-secret="{noop}<grafana-plaintext-secret>" \
-  --from-literal=ha-client-secret="{noop}<ha-plaintext-secret>"
+  --from-literal=ha-client-secret="{noop}<ha-plaintext-secret>" \
+  --from-literal=device-service-client-secret="{noop}<device-service-plaintext-secret>"
 ```
 
 More secure: pre-hash with BCrypt and prefix with `{bcrypt}`:
@@ -89,6 +90,11 @@ env:
       secretKeyRef:
         name: homelab-auth-secrets
         key: ha-client-secret
+  - name: DEVICE_SERVICE_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: homelab-auth-secrets
+        key: device-service-client-secret
 ```
 
 ### Sentry DSN (optional)

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -235,6 +235,7 @@ spring:
 | `APP_JWT_PUBLIC_KEY` | `file:/etc/secrets/public.pem` | RSA public key path (volume mount) |
 | `GRAFANA_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `grafana-client-secret` | Grafana OIDC client secret (plaintext) |
 | `HA_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `ha-client-secret` | Home Assistant OIDC client secret (plaintext) |
+| `DEVICE_SERVICE_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `device-service-client-secret` | device-service OIDC client secret (plaintext) |
 
 RSA keys are mounted from Secret `homelab-auth-rsa-keys` at `/etc/secrets/`.
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,11 @@ spec:
                 secretKeyRef:
                   name: homelab-auth-secrets
                   key: ha-client-secret
+            - name: DEVICE_SERVICE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-auth-secrets
+                  key: device-service-client-secret
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,6 +47,15 @@ app:
         post-logout-redirect-uris:
           - https://ha.furchert.ch
         scopes: [openid, profile, email]
+      - client-id: device-service
+        # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
+        client-secret: "${DEVICE_SERVICE_CLIENT_SECRET}"
+        redirect-uris:
+          - https://device.furchert.ch/login/oauth2/code/device-service
+          - http://localhost:8081/login/oauth2/code/device-service
+        post-logout-redirect-uris:
+          - https://device.furchert.ch
+        scopes: [openid, profile, email]
 
 management:
   endpoints:


### PR DESCRIPTION
This pull request introduces improvements to CI workflow management and updates to OAuth2 client configuration. The most significant changes are the addition of concurrency controls to GitHub Actions workflows to prevent overlapping runs, and the registration of a new OAuth2 client for the device service in the application configuration.

**CI/CD Workflow Improvements:**

* Added concurrency groups to `.github/workflows/build.yml` and `.github/workflows/codeql.yml` to ensure that only one workflow run per pull request or branch is active at a time, canceling any in-progress runs when a new one is triggered. This helps avoid redundant builds and ensures resources are used efficiently. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R15-R18) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R22-R25)

**OAuth2 Client Configuration:**

* Registered a new OAuth2 client (`device-service`) in `application.yaml`, including client ID, secret, redirect URIs, post-logout redirect URIs, and scopes. This enables secure authentication for the device service component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC authentication configuration for device service, enabling secure login with OpenID Connect.

* **Chores**
  * Optimized CI/CD workflows with concurrency controls to cancel redundant builds and improve resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->