### PR TITLE
# fix: wire DEVICE_SERVICE_CLIENT_SECRET into auth-service deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - JWKS endpoint at `/oauth2/jwks` (replaces `/api/v1/auth/jwks`)
 - UserInfo endpoint at `/userinfo`
 - RP-Initiated Logout at `/connect/logout`
-- Pre-configured OIDC clients: `grafana`, `home-assistant`, `device-service`, `n8n`
+- Pre-configured OIDC clients: `grafana`, `homeassistant`, `device-service`, `n8n`
 - Flyway V3 migration: creates `oauth2_authorization` and `oauth2_authorization_consent` tables for Spring Authorization Server
 - Flyway V4 migration: drops legacy `refresh_tokens` table
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - JWKS endpoint at `/oauth2/jwks` (replaces `/api/v1/auth/jwks`)
 - UserInfo endpoint at `/userinfo`
 - RP-Initiated Logout at `/connect/logout`
-- Pre-configured OIDC clients: `grafana`, `home-assistant`
+- Pre-configured OIDC clients: `grafana`, `home-assistant`, `device-service`, `n8n`
 - Flyway V3 migration: creates `oauth2_authorization` and `oauth2_authorization_consent` tables for Spring Authorization Server
 - Flyway V4 migration: drops legacy `refresh_tokens` table
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -66,7 +66,8 @@ Simplest approach (homelab): prefix with `{noop}` so the secret is matched as-is
 kubectl create secret generic homelab-auth-secrets -n apps \
   --from-literal=grafana-client-secret="{noop}<grafana-plaintext-secret>" \
   --from-literal=ha-client-secret="{noop}<ha-plaintext-secret>" \
-  --from-literal=device-service-client-secret="{noop}<device-service-plaintext-secret>"
+  --from-literal=device-service-client-secret="{noop}<device-service-plaintext-secret>" \
+  --from-literal=n8n-client-secret-authservice="{noop}<n8n-plaintext-secret>"
 ```
 
 More secure: pre-hash with BCrypt and prefix with `{bcrypt}`:
@@ -95,6 +96,11 @@ env:
       secretKeyRef:
         name: homelab-auth-secrets
         key: device-service-client-secret
+  - name: N8N_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: homelab-auth-secrets
+        key: n8n-client-secret-authservice
 ```
 
 ### Sentry DSN (optional)

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -236,6 +236,7 @@ spring:
 | `GRAFANA_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `grafana-client-secret` | Grafana OIDC client secret (plaintext) |
 | `HA_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `ha-client-secret` | Home Assistant OIDC client secret (plaintext) |
 | `DEVICE_SERVICE_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `device-service-client-secret` | device-service OIDC client secret (plaintext) |
+| `N8N_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `n8n-client-secret-authservice` | n8n OIDC client secret for auth-service (must include `{id}` prefix) |
 
 RSA keys are mounted from Secret `homelab-auth-rsa-keys` at `/etc/secrets/`.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ OIDC Identity Provider (Spring Authorization Server) for the doemefu homelab IoT
 
 - OIDC Identity Provider (Spring Authorization Server) for SSO across furchert.ch homelab services
 - OIDC Discovery at `/.well-known/openid-configuration`
-- Authorization Code Flow with PKCE for Grafana, Home Assistant, and other clients
+- Authorization Code Flow with PKCE for Grafana, Home Assistant, n8n, and other clients
 - JWKS endpoint (`/oauth2/jwks`) for downstream services to validate tokens
 - User CRUD (create, read, update, delete, password reset) via admin API
 - Role-based access control: `USER`, `ADMIN`
@@ -116,6 +116,8 @@ export DB_PASSWORD=homelab
 | `app.oidc.issuer` | — | — (required; must match the public ingress URL exactly) |
 | `app.oidc.clients[0].client-secret` | `GRAFANA_CLIENT_SECRET` | — (required; must include `{id}` prefix, e.g. `{noop}secret`) |
 | `app.oidc.clients[1].client-secret` | `HA_CLIENT_SECRET` | — (required; must include `{id}` prefix, e.g. `{noop}secret`) |
+| `app.oidc.clients[2].client-secret` | `DEVICE_SERVICE_CLIENT_SECRET` | — (required; must include `{id}` prefix, e.g. `{noop}secret`) |
+| `app.oidc.clients[3].client-secret` | `N8N_CLIENT_SECRET` | — (required; must include `{id}` prefix, e.g. `{noop}secret`) |
 
 Expired OAuth2 authorizations are automatically purged every hour by `TokenCleanupScheduler`. No additional configuration required.
 
@@ -140,6 +142,7 @@ This service is 1 of 3 microservices in the homelab IoT stack.
 ```
 auth-service   ──OIDC SSO──>  Grafana
                     └──>  Home Assistant
+                    └──>  n8n
                     └──JWKS──>  device-service
                     └──JWKS──>  data-service
 ```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -54,6 +54,11 @@ spec:
                 secretKeyRef:
                   name: homelab-auth-secrets
                   key: device-service-client-secret
+            - name: N8N_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-auth-secrets
+                  key: n8n-client-secret-authservice
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -58,6 +58,9 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: homelab-auth-secrets
+                  # auth-service expects Spring Security encoded secret ({noop}/{bcrypt}).
+                  # We keep a dedicated key so n8n can consume the same client secret in raw form
+                  # from a different key without the Spring prefix.
                   key: n8n-client-secret-authservice
             - name: SENTRY_DSN
               valueFrom:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,14 @@ app:
         post-logout-redirect-uris:
           - https://device.furchert.ch
         scopes: [openid, profile, email]
+      - client-id: n8n
+        # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
+        client-secret: "${N8N_CLIENT_SECRET}"
+        redirect-uris:
+          - https://n8n.furchert.ch/rest/sso/oidc/callback
+        post-logout-redirect-uris:
+          - https://n8n.furchert.ch
+        scopes: [openid, profile, email]
 
 management:
   endpoints:


### PR DESCRIPTION
  Add missing env var to k8s/deployment.yaml (referenced in application.yaml but not previously injected into the pod). Update DEPLOYMENT.md kubectl create secret command and yaml snippet, and add the new var to the OPERATIONS.md environment variable table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * N8n is now supported as an OIDC authentication provider, enabling single sign-on integration.

* **Documentation**
  * Updated deployment and configuration documentation to include n8n as a supported OAuth/OIDC provider.
  * Updated architecture diagrams to show authentication flows to n8n.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->