### PR TITLE
+ inject LITELLM_CLIENT_SE…

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -67,7 +67,8 @@ kubectl create secret generic homelab-auth-secrets -n apps \
   --from-literal=grafana-client-secret="{noop}<grafana-plaintext-secret>" \
   --from-literal=ha-client-secret="{noop}<ha-plaintext-secret>" \
   --from-literal=device-service-client-secret="{noop}<device-service-plaintext-secret>" \
-  --from-literal=n8n-client-secret-authservice="{noop}<n8n-plaintext-secret>"
+  --from-literal=n8n-client-secret-authservice="{noop}<n8n-plaintext-secret>" \
+  --from-literal=litellm-client-secret-authservice="{noop}<litellm-plaintext-secret>"
 ```
 
 More secure: pre-hash with BCrypt and prefix with `{bcrypt}`:
@@ -101,6 +102,11 @@ env:
       secretKeyRef:
         name: homelab-auth-secrets
         key: n8n-client-secret-authservice
+  - name: LITELLM_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: homelab-auth-secrets
+        key: litellm-client-secret-authservice
 ```
 
 ### Sentry DSN (optional)

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -237,6 +237,7 @@ spring:
 | `HA_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `ha-client-secret` | Home Assistant OIDC client secret (plaintext) |
 | `DEVICE_SERVICE_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `device-service-client-secret` | device-service OIDC client secret (plaintext) |
 | `N8N_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `n8n-client-secret-authservice` | n8n OIDC client secret for auth-service (must include `{id}` prefix) |
+| `LITELLM_CLIENT_SECRET` | Secret `homelab-auth-secrets` / key `litellm-client-secret-authservice` | LiteLLM OIDC client secret for auth-service (must include `{id}` prefix) |
 
 RSA keys are mounted from Secret `homelab-auth-rsa-keys` at `/etc/secrets/`.
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -66,6 +66,9 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: homelab-auth-secrets
+                  # auth-service expects Spring Security encoded secret ({noop}/{bcrypt}).
+                  # We keep a dedicated key so LiteLLM can consume the same client secret in raw form
+                  # from a different key without the Spring prefix.
                   key: litellm-client-secret-authservice
             - name: SENTRY_DSN
               valueFrom:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -62,6 +62,11 @@ spec:
                   # We keep a dedicated key so n8n can consume the same client secret in raw form
                   # from a different key without the Spring prefix.
                   key: n8n-client-secret-authservice
+            - name: LITELLM_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-auth-secrets
+                  key: litellm-client-secret-authservice
             - name: SENTRY_DSN
               valueFrom:
                 secretKeyRef:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,6 +64,14 @@ app:
         post-logout-redirect-uris:
           - https://n8n.furchert.ch
         scopes: [openid, profile, email]
+      - client-id: litellm
+        # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
+        client-secret: "${LITELLM_CLIENT_SECRET}"
+        redirect-uris:
+          - https://ai.furchert.ch/sso/callback
+        post-logout-redirect-uris:
+          - https://ai.furchert.ch
+        scopes: [openid, profile, email]
 
 management:
   endpoints:


### PR DESCRIPTION
This pull request adds support for a new OAuth2 client configuration for the `litellm` application. The changes ensure that the `litellm` client credentials are securely managed and made available to the application via environment variables and Kubernetes secrets.

**OAuth2 client configuration:**

* Added a new OAuth2 client entry for `litellm` in `application.yaml`, including its client ID, secret (referenced from the `LITELLM_CLIENT_SECRET` environment variable), redirect URIs, post-logout redirect URIs, and required scopes.

**Kubernetes secret management:**

* Updated the Kubernetes deployment (`k8s/deployment.yaml`) to inject the `LITELLM_CLIENT_SECRET` environment variable from the `homelab-auth-secrets` secret, ensuring the application can access the `litellm` client secret securely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added OIDC client configuration to enable single sign-on authentication capabilities.
  * Updated authentication service with required secret credentials for external identity provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->