### PR TITLE
UI device handling

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -2,12 +2,30 @@
 
 <!-- Newest entry at the top. Each block: id, date, decision/status, worklog link, open items. -->
 
+- [Method security required](feedback_method_security_required.md) — @PreAuthorize is silently ignored without @EnableMethodSecurity; AuthorizationDeniedException needs explicit 403 mapping
+- [SS7 JWT scope shape](feedback_ss7_jwt_scope_shape.md) — JWT payload encodes `scope` as array, token response as string
 - [SS7 OAuth2 AS API](feedback_ss7_oauth2_api.md) — Use http.oauth2AuthorizationServer() not static authorizationServer()
 - [MockMvc query string](feedback_mockmvc_querystring.md) — MockMvc .param() doesn't set query string; use UriComponentsBuilder for GET AS endpoints
 - [Testcontainers lifecycle](feedback_testcontainers_lifecycle.md) — Use @Testcontainers + @Container, never static initializer — static breaks with multiple Spring contexts
 - [TokenCleanupScheduler SQL](feedback_cleanup_scheduler_sql.md) — COALESCE-to-epoch inside GREATEST matches all-NULL rows; always guard with IS NOT NULL
 - [OIDC client secret prefix](feedback_oidc_secret_prefix.md) — DelegatingPasswordEncoder requires {noop}/{bcrypt} prefix; missing prefix = BCrypt mismatch = silent auth failure
 - [Jackson 3 imports](feedback_jackson3_imports.md) — Project uses tools.jackson (Jackson 3), not com.fasterxml.jackson (Jackson 2)
+
+## 2026-05-13 — IoT Device OAuth2 Clients shipped (JDBC repo + admin API)
+
+**Decision:** Implemented `docs/SPEC-iot-device-clients.md`. Switched Spring AS `RegisteredClientRepository` from in-memory to JDBC via Flyway V5 (`oauth2_registered_client` + `client_kind` extension column). Added `StaticClientSeeder` (idempotent YAML→DB bootstrap), `/api/v1/clients` admin CRUD (gated by `hasRole('ADMIN') or hasAuthority('SCOPE_clients:admin')`), `device_id` JWT claim for `client_credentials` tokens with `client_kind='device'`, `ClientKindLookup` per-JVM cache. `device-service` client is now multi-grant (auth_code + refresh_token + client_credentials) with `clients:admin` scope. `@EnableMethodSecurity` enabled.
+**Worklog:** `.claude/worklogs/20260513-113126-iot-device-clients-x7p3.md`
+**Plan:** `~/.claude/plans/implement-docs-spec-iot-device-clients-m-cozy-sedgewick.md`
+**Spec:** `docs/SPEC-iot-device-clients.md`
+**Status:** done — 88/88 tests pass (`./mvnw verify`), pending commit by user
+**Plan-reviewer findings:** 3 blockers (F1 secret double-encode, F2 method-security off, F3 converter NPE) + 1 high-impact warning (F4 SSO-client delete data loss) all fixed and verified by dedicated tests before any code was committed.
+**Open:**
+- User must commit + push (workflow rule: never auto-commit)
+- Operator runbook change: SSO client-secret rotation now requires `psql UPDATE oauth2_registered_client SET client_secret = ...` (YAML env var alone is no-op after first boot) — documented in OPERATIONS.md
+- Operator runbook change: manual `client_kind` edits via psql require `kubectl rollout restart` (cache)
+- HA follow-up: replace `ClientKindLookup` in-memory cache if auth-service ever scales > 1 replica
+- GitHub project status: read:project scope was missing during session — move item to **Done** manually
+- Mosquitto JWT plugin config to consume `device_id` claim lives in `infrastructure/053-mqtt-device-authentication.md` (out of scope here)
 
 ## 2026-04-11 — PR #15 review fixes (10 Copilot + CodeQL findings)
 

--- a/.claude/memory/feedback_method_security_required.md
+++ b/.claude/memory/feedback_method_security_required.md
@@ -1,0 +1,17 @@
+---
+name: method-security-required
+description: '@PreAuthorize is silently ignored without @EnableMethodSecurity. AuthorizationDeniedException must be mapped to 403 in GlobalExceptionHandler or generic 500 kicks in.'
+metadata:
+  type: feedback
+---
+
+`@PreAuthorize` on a Spring controller method is **silently ignored** unless `@EnableMethodSecurity` is present on a `@Configuration` class (default `prePostEnabled=true` since SS6). The endpoint will reach the controller as long as the filter chain authenticates the request, regardless of authority requirements.
+
+**Why:** Method security is opt-in to keep the spring-security-config dependency surface minimal. The annotation is only an AOP marker — without `@EnableMethodSecurity` the post-processor that wires the security advisor never runs.
+
+**How to apply:**
+- Whenever introducing `@PreAuthorize`, verify (or add) `@EnableMethodSecurity` on `SecurityConfig`.
+- In Spring Security 7+, denied checks throw `org.springframework.security.authorization.AuthorizationDeniedException` (NOT the legacy `AccessDeniedException`). If the project has a `@RestControllerAdvice` with `@ExceptionHandler(Exception.class)` catch-all, it will return 500 instead of 403. Always register an explicit handler that returns 403 for both `AuthorizationDeniedException` AND `AccessDeniedException`.
+- Add a unit test that calls the endpoint with an insufficient authority and asserts `403` — without that test, both regressions are invisible.
+
+Related: [[feedback_oidc_secret_prefix]] (similar silent-failure pattern with DelegatingPasswordEncoder).

--- a/.claude/memory/feedback_ss7_jwt_scope_shape.md
+++ b/.claude/memory/feedback_ss7_jwt_scope_shape.md
@@ -1,0 +1,24 @@
+---
+name: ss7-jwt-scope-shape
+description: Spring AS 7 serialises the `scope` claim inside JWT payload as a JSON array, while the token endpoint response uses a space-separated string. Token tests reading the JWT must parse `scope` as ArrayNode.
+metadata:
+  type: feedback
+---
+
+In Spring Authorization Server 7.0.5, the JWT payload (`access_token`) emits the `scope` claim as a JSON array:
+
+```json
+"scope": ["mqtt:pub", "mqtt:sub"]
+```
+
+The `/oauth2/token` response body, however, returns the scope as a space-separated string:
+
+```json
+"scope": "mqtt:pub mqtt:sub"
+```
+
+**Why:** Both formats are spec-compliant — RFC 6749 §3.3 defines token-response scope as space-delimited, while JWT profile (RFC 9068) does not normatively constrain `scope` shape and Spring AS picks an array.
+
+**How to apply:** Integration tests that base64-decode the JWT payload and assert `scope` must use `JsonNode.isArray()` / `objectMapper.readValue(... List.class)`. `.asText()` on an `ArrayNode` throws a `JsonNodeException` in Jackson 3.
+
+Related: [[feedback_jackson3_imports]] — tests live under `tools.jackson.databind`.

--- a/.claude/worklogs/20260513-113126-iot-device-clients-x7p3.md
+++ b/.claude/worklogs/20260513-113126-iot-device-clients-x7p3.md
@@ -1,0 +1,220 @@
+---
+id: "20260513-113126-iot-device-clients-x7p3"
+title: "IoT Device OAuth2 Clients — JDBC repo + admin API"
+phase: "done"
+status: "done"
+created_at: "2026-05-13T11:31:26+01:00"
+updated_at: "2026-05-13T15:55:00+01:00"
+---
+
+## 1. research
+
+**Goal:** Allow dynamic registration/revocation of OAuth2 `client_credentials` clients for IoT devices, served from Postgres, exposed via an admin REST API consumed by `device-service` and ADMIN users.
+
+**Current state:**
+- `AuthorizationServerConfig.registeredClientRepository()` builds an `InMemoryRegisteredClientRepository` from `app.oidc.clients` (5 static SSO clients).
+- `OAuth2AuthorizationService` is already JDBC-backed (`JdbcOAuth2AuthorizationService` + Flyway V3).
+- No `oauth2_registered_client` table; no `client_credentials` grant; no admin client-management API.
+- `tokenCustomizer()` adds a `role` claim derived from the principal's first authority — only fires for user-driven grants.
+- Resource-server filter chain in `SecurityConfig` protects `/api/v1/**` via role-based rules; JWT authorities are extracted from the `role` claim only (no `scope` authorities currently).
+
+**Repo areas inspected:**
+- `src/main/java/ch/furchert/homelab/auth/config/AuthorizationServerConfig.java` — registeredClientRepository, tokenCustomizer, authorizationService (JdbcOperations already wired)
+- `src/main/java/ch/furchert/homelab/auth/config/OidcClientProperties.java` — `clients[]` shape
+- `src/main/java/ch/furchert/homelab/auth/config/SecurityConfig.java` — apiSecurityFilterChain (order 2), JwtAuthenticationConverter
+- `src/main/java/ch/furchert/homelab/auth/controller/UserController.java` — existing admin endpoints (uses an `isAdmin()` helper, not `@PreAuthorize`)
+- `src/main/java/ch/furchert/homelab/auth/service/UserService.java` lines 125-129 — side-write JDBC pattern (`DELETE FROM oauth2_authorization …`)
+- `src/main/resources/db/migration/V1..V4__*.sql` — conventions: `timestamp with time zone`, `IF NOT EXISTS`, `SET timezone='UTC'`
+- `src/test/java/ch/furchert/homelab/auth/integration/{AbstractIntegrationTest,OidcFlowIntegrationTest,FlywayMigrationTest}.java` — Testcontainers Postgres 17-alpine; PKCE+session-based auth_code flow already covered; helpers `generateCodeVerifier`/`generateCodeChallenge`/`extractParam`.
+- `pom.xml` — Spring Boot 4.0.6 parent (note: CLAUDE.md says 4.0.5, but the pom currently declares 4.0.6); Spring AS 7.0.5; PostgreSQL 42.7.11.
+
+**Git history notes:**
+- Branch `ui-device-handling` adds `docs/SPEC-iot-device-clients.md` (only file new).
+- Recent commits (chore: image bumps, dependabot postgresql 42.7.11) — no related code changes.
+
+**Assumptions:**
+- A1: `spring-boot-starter-jdbc` is on classpath via `spring-boot-starter-data-jpa` (transitive); `JdbcOperations` is auto-configured. [high]
+- A2: `JdbcRegisteredClientRepository.save()` only writes the 13 standard columns; the side-write to `client_kind` after `save()` is safe. [high]
+- A3: Adding a second `client_credentials` grant to `device-service` does not break existing auth_code SSO. PKCE setting (`requireProofKey(true)`) only applies on the auth_code path; client_credentials ignores it. [medium → verify in integration test]
+- A4: Single-replica deploy today; in-memory cache for `client_kind` in `tokenCustomizer` is acceptable. [high]
+- A5: DELETE is idempotent (always 204). [high — per SPEC test list "idempotent delete"]
+
+**Open questions:** none blocker — clarifications captured in Phase 2.
+
+**Research summary:**
+- Spring Authorization Server 7 ships a stock `oauth2_registered_client` schema; adopting it requires a new Flyway V5 migration + swap from `InMemoryRegisteredClientRepository` to `JdbcRegisteredClientRepository(JdbcOperations)`.
+- The `client_kind` column extension is best handled by stock JDBC repo + side-write, mirroring existing `UserService.revokeAuthorizations` pattern.
+- S2S authorization for `/api/v1/clients` is cleanest via an extra `client_credentials` grant + `clients:admin` scope on the `device-service` client; requires extending `JwtAuthenticationConverter` to emit both `ROLE_*` and `SCOPE_*` authorities.
+
+---
+
+## 2. plan
+
+> Authoritative plan lives in the approved plan file:
+> `/Users/dominic/.claude/plans/implement-docs-spec-iot-device-clients-m-cozy-sedgewick.md`.
+>
+> The plan was approved via plan mode on 2026-05-13. The summary, options, changes (C1–C9), tests, validation, risks, and ship notes appear there in full.
+>
+> Findings from Phase 3 (next section) are applied **back into the plan file** and a short delta is recorded here.
+
+**Plan summary (3 bullets):**
+- **Scope:** V5 migration + `JdbcRegisteredClientRepository`, `StaticClientSeeder`, `/api/v1/clients` CRUD, `device_id` claim on client_kind='device' tokens, multi-grant `device-service` with `clients:admin` scope.
+- **Tests:** unit (`DeviceClientServiceTest`, `StaticClientSeederTest`, `TokenCustomizerDeviceIdTest`), MockMvc (`DeviceClientControllerTest`), Testcontainers (extend `OidcFlowIntegrationTest` + `FlywayMigrationTest`, new `DeviceClientLifecycleIT`).
+- **Risks:** plaintext secret leak via logs (high impact, mitigated by no-body-logging policy); `device-service` multi-grant could regress SSO (covered by existing `OidcFlowIntegrationTest`); cache staleness for `client_kind` (acceptable in single replica).
+
+---
+
+## 3. review
+
+**plan-reviewer invoked:** yes — 2026-05-13T11:31
+
+**Verdict:** FAIL → revised plan → **READY**. All 3 blockers addressed; 8 warnings addressed; 4 info items addressed (1 deferred as follow-up).
+
+**Findings table:**
+
+| ID | Severity | Finding | Action taken |
+|----|----------|---------|--------------|
+| F1 | blocker | Contradictory secret handling in seeder — `passwordEncoder.encode()` on a `{bcrypt}...` YAML value double-hashes and silently breaks SSO. | Plan §C3 updated: pass YAML secret verbatim; drop `PasswordEncoder` from seeder. Memory `feedback_oidc_secret_prefix` cited. Added seeder test asserting persisted hash equals YAML. |
+| F2 | blocker | `@PreAuthorize` is silently ignored without `@EnableMethodSecurity`. | Plan §C5+§C8 updated: `@EnableMethodSecurity` added to `SecurityConfig`. Added MockMvc test "plain user JWT → 403" to catch any regression. |
+| F3 | blocker | New `JwtAuthenticationConverter` merge can NPE when either claim is absent; also expands auth surface (SSO JWTs get `SCOPE_openid` etc.). | Plan §C8 updated: null-guard both branches. Added `SecurityConfigConverterTest` covering all 4 claim-presence combinations + the negative case "SSO JWT does NOT grant clients:admin". Documented attack-surface impact (no `hasAuthority("SCOPE_*")` is used today). |
+| F4 | warning (high impact) | `DELETE /api/v1/clients/grafana` would wipe `oauth2_authorization` rows for grafana (logs all users out) before the guarded final DELETE no-ops. | Plan §C4 updated: SELECT-with-`client_kind='device'` filter runs FIRST; non-device → return silently, no side effects. Test added: assert SSO rows untouched after such a call. |
+| F5 | warning | "DELETE invalidates outstanding tokens" overstates JWT semantics — JWTs are self-contained until `exp`. | Plan §C4 documents the 1-hour eventual-revocation window. `DeviceClientLifecycleIT` explicitly tests that the previously-issued JWT still validates until expiry. OPERATIONS.md will spell this out. |
+| F6 | warning | Customizer must default-deny on cache miss / unknown `client_kind`. | Plan §C6 updated: `ClientKindLookup` returns the literal string; customizer only emits `device_id` when value `equals("device")`. Test covers null + `"sso"` + `"device"`. |
+| F7 | warning | Plan contained an incorrect note about `requireProofKey(false)` for `device-service`'s client_credentials half — `ClientSettings` is per-client, not per-grant. | Plan §C7 corrected: keep `requireProofKey(true)` for `device-service`; PKCE only matters on auth_code endpoint. Tests verify Grafana auth_code, device-service auth_code, and device-service client_credentials all work after the change. |
+| F8 | warning | `save()` + `UPDATE client_kind` not atomic — JVM crash between writes leaves a new device client as `sso`. | Plan §C4: `DeviceClientService` is `@Transactional`; the two writes are in one TX. |
+| F9 | info | Seeder's `UPDATE ... SET client_kind='sso'` is redundant given the DEFAULT. | Plan §C3 drops the redundant write. |
+| F10 | warning | Removing the "no clients configured" exception silently allows an empty DB to boot. | Plan §C3: seeder logs INFO "seeded N of M" and WARN if total = 0. |
+| F11 | warning | `MockMvc.param()` doesn't populate query string for AS endpoints (per memory `feedback_mockmvc_querystring`). | Plan tests: `/oauth2/token` requests in integration tests use `.contentType(APPLICATION_FORM_URLENCODED).content(...)` (POST is fine but explicit form body avoids the gotcha). |
+| F12 | warning | MockMvc `.authorities()` bypasses real converter — controller test alone doesn't verify role+scope merge. | Plan adds dedicated `SecurityConfigConverterTest` (pure unit, feeds real `Jwt`). |
+| F13 | info | C9 originally proposed a WebFilter for Sentry body filtering — scope creep. | Plan §C9 scoped down to documentation + verifying Sentry config; only add filter if inspection finds capture. |
+| F14 | info | `DeviceClientsProperties` would be dead config (TTL hardcoded). | Plan §C4 wires `access-token-ttl-seconds` and validates requested scopes against `allowed-scopes`. |
+| F15 | info | No drive-by refactors; deps unchanged. | No action. |
+| F16 | info | No rollback path documented. | Plan §Ship-notes documents emergency rollback (V5 drop + image downgrade; device clients lost; YAML SSO clients reseeded). |
+| Q1 | architectural | Why `clients:admin` scope vs forwarding admin JWT? | Captured in Phase 2 user-clarification (Option chosen). Alternative documented as a future option in the worklog — no change to current plan. |
+| Q2 | architectural | Subclass `JdbcRegisteredClientRepository.RegisteredClientParametersMapper` instead of side-write? | Investigated: Spring AS 7.0.5 `RegisteredClientParametersMapper` is public-static but is a `Function<RegisteredClient, List<SqlParameterValue>>`; the matching `RegisteredClientRowMapper` is also public. Subclassing is feasible but requires owning the JSON `client_settings`/`token_settings` serialisation. Side-write keeps the implementation 30 lines smaller. Decision: stick with Option 1. |
+| Q3 | architectural | Derive `client_kind` from grant type in SQL? | Functionally equivalent for `device`-only but loses the index, loses operator-friendly free-text classification, and SPEC explicitly mandates the column. Decision: keep as column. |
+| Q4 | architectural | 1-hour revocation window acceptable? | Decision: yes — documented in OPERATIONS. Mosquitto introspection is in `infrastructure/053-*` and out of scope here. |
+| Q5 | architectural | Single-replica assumption documented? | Yes — added to Ship notes; follow-up if HA introduced. |
+
+**Architectural questions raised:** Q1–Q5 above.
+
+**Plan updates applied in plan file:**
+- §C3 — secret pass-through (F1), drop redundant UPDATE (F9), add seeder log line (F10).
+- §C4 — `@Transactional`, fixed delete path (F4, F8), wire TTL property (F14), document revocation caveat (F5).
+- §C5 — `@EnableMethodSecurity` required (F2).
+- §C6 — `ClientKindLookup` extracted, default-deny on miss (F6).
+- §C7 — drop incorrect PKCE note (F7), wire `DeviceClientsProperties` (F14).
+- §C8 — null-guarded converter, attack-surface audit (F3); method-level `@PreAuthorize` simplification.
+- §C9 — scope-down: docs + verify, no `WebFilter` unless needed (F13).
+- §Tests — added `SecurityConfigConverterTest`, `ClientKindLookupTest`; expanded `DeviceClientControllerTest` and `DeviceClientServiceTest` (F4 regression coverage); use `.contentType(...)` not `.param()` for token endpoint (F11).
+- §Ship-notes — rollback paragraph (F16), single-replica caveat (Q5).
+
+**Review summary (3 bullets):**
+- 3 blockers (F1 secret-double-encoding, F2 method-security off, F3 converter NPE) all addressed in revised plan.
+- F4 was the most-impactful subtle defect (SSO-client session wipe via `DELETE /api/v1/clients/grafana`) — fix is to filter by `client_kind='device'` BEFORE any DELETE; explicit regression test added.
+- Plan is ready for implementation. Next step: GitHub status → **Planned**, then begin Phase 4.
+
+---
+
+## 4. implement
+
+**Implementation approach:** Plan-driven, no TDD (existing test patterns first; new tests written alongside production code in same batch).
+
+**Changes made:**
+- C1 `src/main/resources/db/migration/V5__oauth2_registered_client.sql` — new SAS 7.0.5 stock schema with `timestamptz`, plus `client_kind VARCHAR(20) NOT NULL DEFAULT 'sso'` + index.
+- C2 `AuthorizationServerConfig.java` — replaced `InMemoryRegisteredClientRepository` build with `JdbcRegisteredClientRepository(JdbcOperations)`; dropped `RsaKeyProperties` and `OidcClientProperties.clients` build logic; extended `tokenCustomizer` to add `device_id` claim when grant=`client_credentials` AND `client_kind='device'` (via `ClientKindLookup`).
+- C3 `StaticClientSeeder.java` (new) — ApplicationRunner; iterates `app.oidc.clients`; `findByClientId` skip-if-present; passes YAML secret through verbatim (no re-encode — F1); reads `grantTypes` per client (default `[auth_code, refresh_token]`); INFO/WARN log line on total count.
+- C4 `DeviceClientService.java` (new) — `@Transactional`; SecureRandom→Base64URL secret; `passwordEncoder.encode()` with `{bcrypt}` fail-fast assert; save + side-write `client_kind='device'`; `list/get` filter by `client_kind='device'`; `delete` SELECTs with `client_kind='device'` filter FIRST so SSO clients are untouched (F4 fix).
+- C5 `DeviceClientController.java` (new) + 3 DTO records — thin controller, `@PreAuthorize("hasRole('ADMIN') or hasAuthority('SCOPE_clients:admin')")` at class level.
+- C6 `ClientKindLookup.java` (new) — `ConcurrentHashMap` cache; default-deny on miss (F6).
+- C7 `application.yaml` — `app.oidc.device-clients.*` block; `device-service` gains `clients:admin` scope + `grant-types: [auth_code, refresh_token, client_credentials]`.
+- C7 `OidcClientProperties.java` — added `grantTypes` (default back-compat) and `DeviceClientsProperties` (`accessTokenTtlSeconds`, `allowedScopes`).
+- C8 `SecurityConfig.java` — added `@EnableMethodSecurity` (F2 blocker fix); JwtAuthenticationConverter now merges role+scope, null-guarded (F3); `/api/v1/clients/**` gated via method-level rule.
+- C9 — no new code; verified Sentry config (`send-default-pii: false`, `traces-sample-rate: 0.0`, no body capture).
+- `GlobalExceptionHandler.java` — added `ResourceConflictException` → 409, and `AuthorizationDeniedException` / `AccessDeniedException` → 403 (previously caught by generic 500 handler).
+- `AbstractIntegrationTest.java` — extended `@DynamicPropertySource` overrides to all 5 clients (clients[0..4]) so YAML env-var placeholders never need resolution; clients[2]=device-service preserves multi-grant.
+- Tests added: `ClientKindLookupTest` (5), `DeviceClientServiceTest` (7, incl. F4 SSO-protection), `StaticClientSeederTest` (5, incl. F1 secret pass-through), `DeviceClientControllerTest` (12, incl. F2 plain-user→403), `SecurityConfigConverterTest` (5, incl. null-guard + factor authority filter), `DeviceClientLifecycleIT` (2 full lifecycle), `FlywayMigrationTest` (+2 V5 assertions), `OidcFlowIntegrationTest` (+1 device-service S2S F7).
+
+**Commands and results:**
+```bash
+$ ./mvnw -q compile           # PASS, no warnings
+$ ./mvnw -q test -Dtest='*Test,*IT' -Dtest=…  # 88 tests, 0 failures
+$ ./mvnw -q verify            # PASS — jar built
+```
+Aggregate: `tests=88 errors=0 skipped=0 failures=0`.
+
+**Implementation summary:**
+- All 9 plan changes (C1–C9) implemented; all plan-reviewer blockers (F1, F2, F3) and high-impact F4 fix verified by dedicated tests.
+- Test count went from 53 to 88 (+35 new). Build clean on local Docker + Testcontainers.
+- No external dependencies added; existing version pins respected; no env vars or K8s secrets required.
+
+---
+
+## 5. check implementation
+
+**requesting-code-review invoked:** not separately — Phase 3 `plan-reviewer` findings were applied and verified by dedicated tests (F1 secret pass-through, F2 plain-user→403, F3 null-guard, F4 SSO-protection, F6 default-deny, F7 multi-grant, F8 transactional). User asked for direct implementation, not a second review pass.
+
+**Verification against plan:**
+- [x] All planned changes (C1–C9) completed
+- [x] Planned tests executed — 88 tests pass, 0 failures
+- [x] Validation command successful: `./mvnw verify` green
+- [x] No secret exposure/logging risks — Sentry config inspected; controller Javadoc warns; tests don't log response bodies
+- [x] No unrelated refactors — diff scoped to spec + reviewer findings
+
+**Findings:** none open. Implementation matches the revised plan one-to-one.
+
+**Lessons learned:**
+- DelegatingPasswordEncoder ambiguity bites in tests (`update(String, Object...)` vs `update(String, PreparedStatementSetter)`) — disambiguate with `(Object[]) any(Object[].class)`. Now memorable.
+- Spring Security 7 attaches a `FactorGrantedAuthority(FACTOR_BEARER)` to every resource-server JWT auth — tests must filter for project-emitted authorities or assertions on emptiness will fail.
+- The JWT `scope` claim is serialised as a JSON array by Spring AS (not a space-separated string like the token-endpoint response body). Tests of JWT payload must handle this.
+- `@PreAuthorize` throws `AuthorizationDeniedException` (Spring Security 7) which the catch-all `@ExceptionHandler(Exception.class)` swallows as 500 unless explicitly mapped to 403. This was missed in the plan and surfaced during the first test run.
+
+**Check summary:**
+- All tests green; no critical/high findings.
+- Risk-table items R1–R7 verified with at least one test each.
+- Ship gate: PASS.
+
+---
+
+## 6. ship
+
+**doc-auditor invoked:** yes — returned 31-item list across README/OPERATIONS/CONTRIBUTING/DEPLOYMENT/CHANGELOG. High-priority items applied (README + OPERATIONS + CHANGELOG). CONTRIBUTING + DEPLOYMENT minor notes deferred — none are blocking; user can apply during the doc-rev pass before tagging a release.
+
+**Final verification:**
+- [x] `./mvnw verify` passes (88/88 tests)
+- [x] Integration checks completed via Testcontainers (Postgres 17-alpine); no live cluster check needed for this change
+- [x] Documentation updates applied for README/OPERATIONS/CHANGELOG (CONTRIBUTING/DEPLOYMENT marginal items deferred; see doc-auditor output in Phase 3 transcript)
+
+**Docs to update (proposed):**
+- `README.md` — new section "Device Client Admin API (`/api/v1/clients`)"; bootstrap note that clients are now seeded into DB and managed by `StaticClientSeeder`.
+- `OPERATIONS.md` — revoke a compromised device runbook (DELETE + 1-hour eventual revocation); psql inspection queries; cache-staleness gotcha for manual psql edits; rollback paragraph for V5.
+- `CHANGELOG.md` — `### Added — IoT device OAuth2 clients` entry.
+- `CONTRIBUTING.md` — testing the new endpoints locally; how to acquire an ADMIN JWT.
+
+**Decision log:**
+
+| ID | Decision | Rationale | Impact |
+|----|----------|-----------|--------|
+| D1 | JDBC repo + side-write for `client_kind` | Mirrors `UserService.revokeAuthorizations`; subclassing the SAS row mapper would force re-owning JSON serialisation. | One extra `UPDATE` per device-client create; SSO seed paths use the column DEFAULT instead. |
+| D2 | `clients:admin` scope vs hardcoded sub check | Reusable for future S2S callers; aligns with Spring Security authority model. | New `SCOPE_*` authorities on every JWT (audited — no existing site uses `hasAuthority("SCOPE_*")`). |
+| D3 | `device_id` only when `client_kind='device'` | Strict separation between SSO and device tokens; Mosquitto plugin sees only what it cares about. | One cached lookup per token issuance; default-deny on miss. |
+| D4 | Idempotent DELETE | Matches SPEC test list; simplifies retry logic in `device-service`. | Operators get 204 either way — explicit in OPERATIONS. |
+| D5 | Single-replica cache assumption | auth-service is single-replica today; full revocation already requires 1h TTL anyway. | Follow-up if HA introduced — documented. |
+
+**Final summary:**
+- Added Flyway V5, `JdbcRegisteredClientRepository`, `StaticClientSeeder`, `/api/v1/clients` CRUD, `device_id` claim, and merged role+scope JWT authorities. 35 new tests; all 88 pass.
+- Verified by `./mvnw verify` (Testcontainers Postgres 17-alpine, Docker Desktop local).
+- Follow-ups: doc-auditor still finishing; user to review docs + create commit; if `device-service` ever scales horizontally, replace `ClientKindLookup` cache with a distributed cache or per-request DB read.
+
+**User actions required:**
+- Review proposed docs changes (or doc-auditor output) and apply.
+- Commit using the proposed message (this worklog will be amended in section 6.docs with `doc-auditor invoked: yes` when applied).
+- Set `DEVICE_SERVICE_CLIENT_SECRET` env var in K8s with the **same** value device-service uses for its OAuth2 client secret (no change required — already required in M2; client_credentials grant uses the same secret).
+- Move the corresponding GitHub project item to **Done** (gh project read scope was missing during this session — couldn't be automated).
+
+**Follow-ups:**
+- HA: when scaling auth-service > 1 replica, replace `ClientKindLookup` in-memory cache with a distributed cache or remove the cache entirely (acceptable performance hit).
+- Frontend: device-service frontend can now wire up to `/api/v1/clients` — out of scope here.
+- Mosquitto: configure JWT plugin to use `device_id` claim per `infrastructure/053-mqtt-device-authentication.md`.
+
+**Memory entry added at top of `.claude/memory/MEMORY.md`:** yes — plus two new feedback files: `feedback_method_security_required.md` and `feedback_ss7_jwt_scope_shape.md`.

--- a/.claude/worklogs/20260513-113126-iot-device-clients-x7p3.md
+++ b/.claude/worklogs/20260513-113126-iot-device-clients-x7p3.md
@@ -218,3 +218,36 @@ Aggregate: `tests=88 errors=0 skipped=0 failures=0`.
 - Mosquitto: configure JWT plugin to use `device_id` claim per `infrastructure/053-mqtt-device-authentication.md`.
 
 **Memory entry added at top of `.claude/memory/MEMORY.md`:** yes — plus two new feedback files: `feedback_method_security_required.md` and `feedback_ss7_jwt_scope_shape.md`.
+
+---
+
+## 7. follow-up: SonarQube triage (2026-05-13, post-ship)
+
+User shared a SonarQube report after shipping. Plan + triage at
+`~/.claude/plans/implement-docs-spec-iot-device-clients-m-cozy-sedgewick.md`.
+
+**Fixed inline (9 items, all within this branch's diff):**
+
+| File:line | Rule | Change |
+|-----------|------|--------|
+| `ClientKindLookup.java:52` | S7467 | `catch (… e)` → `catch (… _)` |
+| `DeviceClientService.java:126` | S7467 | `catch (… e)` → `catch (… _)` (in `get`) |
+| `DeviceClientService.java:145` | S7467 | `catch (… e)` → `catch (… _)` (in `delete`) |
+| `DeviceClientLifecycleIT.java:78,96,104,108` | S1874 | `JsonNode.asText()` → `asString()` (×4) |
+| `OidcFlowIntegrationTest.java:224` | S1874 | `asText()` → `asString()` in new test |
+| `OidcFlowIntegrationTest.java:229–230` | S5853 | Chained `assertThat(payload).doesNotContain(...).contains(...)` |
+
+Verification: `./mvnw verify` → `tests=88 errors=0 skipped=0 failures=0` (unchanged from ship).
+
+**Deferred to a separate cleanup PR (out of scope per CLAUDE.md "minimize diff size"):**
+
+| File / area | Rule(s) | Reason for deferral |
+|-------------|---------|----------------------|
+| `AbstractIntegrationTest.java:17,55` | S1874 | Testcontainers `PostgreSQLContainer` API rename — pre-existing, requires verifying the new constructor and CI assumptions. |
+| `AuthorizationServerConfig.java:58,96` | S112, S1130 | `throws Exception` on the filter-chain method — Spring's `HttpSecurity.build()` actually throws Exception; narrowing would be a non-trivial refactor. Pre-existing. |
+| `FlywayMigrationTest.java:16` | S5976 | Could parameterize the 4 table-exists tests, but my contribution was 2 of them; the rule fires because of the count, not because of a regression. Moderate refactor — defer. |
+| `OidcFlowIntegrationTest.java:187,188` | S1874 | Pre-existing `.asText()` in `fullAuthCodeFlowIssuesTokens`. |
+| `OidcUserInfoMapperTest.java` | S5838 | File not modified this session — pure drive-by. |
+| `SecurityConfig.java:38,70,72,94` | S112/S1130/S1192 | `throws Exception` + duplicated `"/login"` literal — pre-existing; I only added `@EnableMethodSecurity` and the merged converter, not the flagged lines. |
+
+These should be picked up in a follow-up sweep PR; no urgency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 - Pre-configured OIDC clients: `grafana`, `homeassistant`, `device-service`, `n8n`
 - Flyway V3 migration: creates `oauth2_authorization` and `oauth2_authorization_consent` tables for Spring Authorization Server
 - Flyway V4 migration: drops legacy `refresh_tokens` table
+- Flyway V5 migration: creates `oauth2_registered_client` (Spring AS JDBC schema) with extension column `client_kind VARCHAR(20) NOT NULL DEFAULT 'sso'`
+- `StaticClientSeeder` — idempotent one-shot bootstrap of YAML-defined SSO clients into the new `oauth2_registered_client` table on first boot
+- Admin REST API `POST/GET/DELETE /api/v1/clients` for IoT device client lifecycle, gated by `hasRole('ADMIN') or hasAuthority('SCOPE_clients:admin')`
+- `device_id` JWT claim emitted on `client_credentials` access tokens where `client_kind='device'` (consumed by Mosquitto JWT plugin)
+- `ResourceConflictException` → HTTP 409; `AuthorizationDeniedException`/`AccessDeniedException` → HTTP 403 in `GlobalExceptionHandler`
+- `@EnableMethodSecurity` enabled globally on `SecurityConfig` so `@PreAuthorize` works on controllers
+- `app.oidc.device-clients.access-token-ttl-seconds` (default 3600) and `allowed-scopes` config properties
 
 ### Changed
 
@@ -28,6 +35,9 @@
 - `PasswordEncoder` switched to `DelegatingPasswordEncoder` to support `{noop}`/`{bcrypt}` prefixes for OIDC client secrets
 - API filter chain is now stateless (no sessions); login form uses a separate stateful filter chain
 - OIDC client secret env vars must include the Spring Security `{id}` prefix (e.g. `{noop}secret`)
+- Registered clients moved from in-memory to JDBC (`oauth2_registered_client`); after first boot, YAML edits to client definitions are no-ops — manage via `psql` or `/api/v1/clients`
+- `device-service` OIDC client extended to multi-grant (`authorization_code` + `refresh_token` + `client_credentials`) with new `clients:admin` scope (for service-to-service calls to `/api/v1/clients`)
+- `JwtAuthenticationConverter` now emits both `ROLE_*` (from `role` claim) and `SCOPE_*` (from `scope` claim) authorities
 
 ### Removed
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -38,6 +38,11 @@ Current migrations:
 - **V2** — Widens `password_hash` to `VARCHAR(255)`, resizes `refresh_tokens.token` to `VARCHAR(64)` (SHA-256 hashes), converts all timestamps to `TIMESTAMPTZ`. Truncates existing refresh tokens (incompatible format after hashing change).
 - **V3** — Creates `oauth2_authorization` and `oauth2_authorization_consent` tables for Spring Authorization Server token storage.
 - **V4** — Drops the legacy `refresh_tokens` table.
+- **V5** — Creates `oauth2_registered_client` (Spring AS JDBC schema) with extension column `client_kind VARCHAR(20) NOT NULL DEFAULT 'sso'`. Switches the registered-client repository from in-memory to JDBC.
+
+### V5 rollback path
+
+V5 is forward-only. Emergency rollback requires dropping `oauth2_registered_client` AND downgrading the auth-service image — both seeded SSO clients and any registered device clients are wiped. The next boot of the older image will reseed YAML SSO clients from in-memory config; **device clients are lost**.
 
 **Never edit or delete existing `V*.sql` migration files.** Flyway checksums will fail.
 
@@ -68,7 +73,60 @@ Then remove `FLYWAY_BASELINE_ON_MIGRATE` from the deployment. Leaving `true` per
 
 ---
 
-## Adding a New OIDC Client
+## Device Client Runbooks
+
+Device OAuth2 clients (`client_kind='device'`) are managed at runtime via `/api/v1/clients`; no redeploy required. SSO clients are seeded once from YAML on first boot.
+
+### Register a new device client
+
+```bash
+ADMIN_JWT=$(...)  # acquire via OIDC auth_code flow as an ADMIN user
+curl -X POST -H "Authorization: Bearer $ADMIN_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"clientId":"terra1","description":"Greenhouse 1"}' \
+  https://auth.furchert.ch/api/v1/clients
+# → 201 { "clientId": "terra1", "clientSecret": "<plaintext, one-time>", … }
+```
+
+Capture the `clientSecret` from the response immediately — it is never shown again.
+
+### Revoke a device client
+
+```bash
+curl -X DELETE -H "Authorization: Bearer $ADMIN_JWT" \
+  https://auth.furchert.ch/api/v1/clients/terra1
+# → 204 (idempotent; returns 204 even if the clientId never existed)
+```
+
+**Revocation is eventual.** Deleting a client removes the registration and revokes AS-side authorizations, but already-issued JWTs remain valid at Mosquitto until they expire (`access-token-ttl-seconds`, default 3600). For immediate revocation, rotate the auth-service RSA key (separate runbook).
+
+DELETE refuses to remove SSO clients silently — the row is preserved and the response is still `204`. Verify with:
+
+```sql
+SELECT client_id, client_kind FROM oauth2_registered_client ORDER BY client_id_issued_at;
+```
+
+### Inspect device clients via psql
+
+```bash
+kubectl port-forward -n apps svc/postgres 5432:5432 &
+PGPASSWORD=… psql -h localhost -U auth -d homelabdb -c \
+  "SELECT client_id, client_kind, client_id_issued_at FROM oauth2_registered_client WHERE client_kind = 'device';"
+```
+
+### Manual psql edits to `client_kind` need a restart
+
+`auth-service` caches the `client_kind` column per registered client in memory. After any direct `UPDATE oauth2_registered_client SET client_kind = ...` via psql, run:
+
+```bash
+kubectl rollout restart deployment/auth-service -n apps
+```
+
+Otherwise newly-tagged "device" clients will not receive the `device_id` JWT claim until restart (or vice versa). The cache assumes a single auth-service replica.
+
+---
+
+## Adding a New OIDC Client (SSO)
 
 1. Choose a client secret and prepare the encoded value for the K8s Secret.
    The env var must contain the full Spring Security encoded form:
@@ -112,29 +170,35 @@ Then remove `FLYWAY_BASELINE_ON_MIGRATE` from the deployment. Leaving `true` per
 
 ## Rotating a Client Secret
 
-1. Prepare the new encoded secret (the env var must include the `{id}` prefix):
+> **Behaviour change since V5:** Registered clients now live in the `oauth2_registered_client` table. `StaticClientSeeder` runs once on first boot and is skip-if-exists, so **simply updating the K8s Secret env var no longer rotates the persisted client secret**. Update the DB directly:
+
+1. Prepare the new encoded secret (must include the `{id}` prefix):
    ```bash
-   # Simplest — no hashing:
-   # value to store: {noop}<new-plaintext-secret>
-   #
-   # More secure — BCrypt hash:
-   htpasswd -bnBC 12 "" <new-secret> | tr -d ':\n'
-   # prefix the output: {bcrypt}$2a$12$...
+   # {noop}<new-plaintext-secret>           — simplest, no hashing
+   htpasswd -bnBC 12 "" <new-secret> | tr -d ':\n'   # then prefix: {bcrypt}$2a$12$...
    ```
 
-2. Update the K8s Secret with the new encoded value:
+2. Update the row in Postgres:
+   ```bash
+   kubectl port-forward -n apps svc/postgres 5432:5432 &
+   PGPASSWORD=… psql -h localhost -U auth -d homelabdb -c \
+     "UPDATE oauth2_registered_client SET client_secret = '{noop}<new-plaintext-secret>' \
+      WHERE client_id = 'grafana';"
+   ```
+
+3. Also update the K8s Secret env var so the YAML stays consistent for fresh deploys / disaster-recovery reseeds:
    ```bash
    kubectl patch secret homelab-auth-secrets -n apps \
      --type merge \
      -p '{"stringData":{"GRAFANA_CLIENT_SECRET":"{noop}<new-plaintext-secret>"}}'
    ```
 
-4. Restart the pod:
+4. Restart auth-service (Spring AS reads `oauth2_registered_client` on each request via `JdbcRegisteredClientRepository`, so this is for safety, not strictly required):
    ```bash
    kubectl rollout restart deployment/auth-service -n apps
    ```
 
-After restart, update the client configuration in the consuming service (Grafana, Home Assistant, etc.) to use the new secret.
+After restart, update the consuming service (Grafana, Home Assistant, etc.) to use the new secret.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ OIDC Identity Provider (Spring Authorization Server) for the doemefu homelab IoT
 - Authorization Code Flow with PKCE for Grafana, Home Assistant, n8n, and other clients
 - JWKS endpoint (`/oauth2/jwks`) for downstream services to validate tokens
 - User CRUD (create, read, update, delete, password reset) via admin API
-- Role-based access control: `USER`, `ADMIN`
+- Admin REST API for IoT device OAuth2 clients (`/api/v1/clients`) — `client_credentials` grant; JWTs carry a `device_id` claim consumed by the Mosquitto JWT plugin
+- JDBC-backed `RegisteredClientRepository`; static SSO clients seeded from YAML on first boot via `StaticClientSeeder`
+- Role-based access control: `USER`, `ADMIN`; scope-based authority `SCOPE_clients:admin` for service-to-service admin calls
 - Automatic purge of expired OAuth2 authorizations (hourly)
 
 **Does NOT:** talk to MQTT, InfluxDB, or any other service at runtime. Fully self-contained.
@@ -45,6 +47,19 @@ All user endpoints are prefixed `/api/v1`.
 | PUT | `/api/v1/users/{id}` | ADMIN | Update user |
 | DELETE | `/api/v1/users/{id}` | ADMIN | Delete user |
 | POST | `/api/v1/users/{id}/reset-password` | ADMIN or self | Reset password (self requires `currentPassword`) |
+
+### Device Client Admin API
+
+Manage IoT device OAuth2 clients (`client_kind='device'`). All endpoints accept either an `ADMIN` JWT or any JWT with the `SCOPE_clients:admin` authority (used by `device-service` for S2S calls).
+
+| Method | Path | Body / Params | Response |
+|--------|------|---------------|----------|
+| POST | `/api/v1/clients` | `{"clientId":"terra1","description":"…"}` (clientId pattern `[a-z0-9-]{3,32}`) | `201 {clientId, clientSecret (plaintext, one-time), scopes, createdAt}` |
+| GET | `/api/v1/clients` | — | `200 [{clientId, description, createdAt, scopes}]` (filters `client_kind='device'`) |
+| GET | `/api/v1/clients/{clientId}` | — | `200` single device client or `404` |
+| DELETE | `/api/v1/clients/{clientId}` | — | `204` (idempotent); refuses to delete SSO clients silently — the row is preserved |
+
+Device clients use the `client_credentials` grant with scopes `mqtt:pub mqtt:sub` and a 1-hour access-token TTL (configurable via `app.oidc.device-clients.access-token-ttl-seconds`). JWTs include a `device_id` claim equal to the `clientId`. Revocation is eventual: existing JWTs remain valid until `exp` after DELETE.
 
 ### Management & Docs
 

--- a/docs/SPEC-iot-device-clients.md
+++ b/docs/SPEC-iot-device-clients.md
@@ -1,0 +1,163 @@
+# SPEC — IoT Device OAuth2 Clients
+
+> Issue MQTT credentials for IoT devices via OAuth2 client-credentials. Devices receive a JWT that Mosquitto validates against `/oauth2/jwks`.
+
+**Status:** draft
+**Cross-references:**
+- `../../device-service/SPEC-device-registration.md` — caller of the new admin API
+- `../../infrastructure/docs/053-mqtt-device-authentication.md` — Mosquitto JWT plugin config
+
+---
+
+## Goal
+
+Allow the homelab admin frontend (via device-service) to dynamically register, list, and revoke OAuth2 clients representing individual IoT devices. Each device authenticates to Mosquitto with a short-lived JWT obtained from `/oauth2/token` (grant `client_credentials`).
+
+---
+
+## Current state
+
+- `AuthorizationServerConfig.registeredClientRepository()` uses **`InMemoryRegisteredClientRepository`** seeded from `app.oidc.clients` in `application.yaml`. Adding a client requires a config change + redeploy.
+- Existing clients all use `AUTHORIZATION_CODE` + `REFRESH_TOKEN` grants for SSO (Grafana, HA, n8n, device-service, litellm).
+- No `oauth2_registered_client` table exists. `OAuth2AuthorizationService` already uses JDBC (V3 migration covers `oauth2_authorization` + `oauth2_authorization_consent`).
+- No support for `client_credentials` grant anywhere.
+
+---
+
+## Required changes
+
+### 1. Flyway V5 — `oauth2_registered_client` table
+
+New migration `V5__oauth2_registered_client.sql`. Use the standard Spring Authorization Server DDL (see `org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository` Javadoc — copy verbatim, adjust types to `timestamp with time zone` to match V2/V3 convention).
+
+Adds one column **not** in the standard DDL:
+
+```sql
+ALTER TABLE oauth2_registered_client
+    ADD COLUMN client_kind VARCHAR(20) NOT NULL DEFAULT 'sso';
+-- Values: 'sso' (Grafana/HA/n8n/etc.) | 'device' (IoT)
+CREATE INDEX idx_oauth2_registered_client_kind ON oauth2_registered_client(client_kind);
+```
+
+`client_kind` is used by the new admin API to filter `GET /api/v1/clients` to device clients only (so SSO clients don't show up in the device frontend).
+
+### 2. Replace `InMemoryRegisteredClientRepository` with `JdbcRegisteredClientRepository`
+
+In `AuthorizationServerConfig.java:98`:
+
+- Return `new JdbcRegisteredClientRepository(jdbcOperations)`.
+- Drop the in-memory list build.
+
+### 3. Seed static SSO clients from config on startup
+
+New `@Component` `StaticClientSeeder implements ApplicationRunner`:
+
+- Iterate `OidcClientProperties.getClients()`.
+- For each: `repo.findByClientId(...)`. If absent → `repo.save(buildRegisteredClient(def))`. If present → no-op (config is the source of truth for *bootstrap*, but updates after first save must go through the admin API or `psql`; document this explicitly).
+- All seeded clients get `client_kind = 'sso'`. Persisting this requires a custom column write — easiest path: keep `client_kind` updates out of `JdbcRegisteredClientRepository` and write it via a small `JdbcTemplate` call right after `save()` (`UPDATE oauth2_registered_client SET client_kind = 'sso' WHERE id = ?`).
+- Run order: after Flyway, before any HTTP traffic. `ApplicationRunner` runs at the right time.
+
+### 4. Admin API — device client lifecycle
+
+New controller `DeviceClientController` under `/api/v1/clients`. Secured: `hasRole('ADMIN')` **OR** authenticated client `device-service` (so service-to-service calls from device-service work without a user session).
+
+| Method | Path | Body / Params | Response |
+|--------|------|---------------|----------|
+| `POST` | `/api/v1/clients` | `{ "clientId": "terra1", "description": "Greenhouse terrarium 1" }` | `201 { "clientId": "terra1", "clientSecret": "<plaintext, one-time>", "scopes": ["mqtt:pub", "mqtt:sub"] }` |
+| `GET` | `/api/v1/clients` | — | `200 [{ "clientId": "terra1", "createdAt": "...", "description": "..." }]` (filters `client_kind='device'`) |
+| `GET` | `/api/v1/clients/{clientId}` | — | `200` single client, or `404` |
+| `DELETE` | `/api/v1/clients/{clientId}` | — | `204` — deletes from `oauth2_registered_client` **and** deletes outstanding rows from `oauth2_authorization` for that client (revokes tokens) |
+
+Device client build defaults:
+
+- Random `clientId` rejected — admin chooses (matches MQTT username, e.g. `terra1`).
+- `clientSecret` generated server-side: 32 random bytes → Base64URL. Stored with `{bcrypt}` prefix. Returned **once** in the create response.
+- Grants: `client_credentials` only.
+- Scopes: `mqtt:pub`, `mqtt:sub`.
+- `clientSettings`: `requireProofKey(false)`, `requireAuthorizationConsent(false)`.
+- `tokenSettings`: `accessTokenTimeToLive(Duration.ofHours(1))`, no refresh tokens.
+- `client_kind = 'device'`.
+
+DTOs:
+
+```java
+public record CreateDeviceClientRequest(
+    @NotBlank @Pattern(regexp="[a-z0-9-]{3,32}") String clientId,
+    @Size(max=200) String description
+) {}
+
+public record DeviceClientResponse(
+    String clientId, String description,
+    Instant createdAt, List<String> scopes
+) {}
+
+public record DeviceClientCreatedResponse(
+    String clientId, String clientSecret,
+    List<String> scopes, Instant createdAt
+) {}
+```
+
+Use a `DeviceClientService` for the logic so the controller stays thin and the same service can be unit-tested without MockMvc.
+
+### 5. Token customizer — `device_id` claim
+
+Extend `tokenCustomizer()` in `AuthorizationServerConfig`:
+
+- For `client_credentials` access tokens, add claim `"device_id"` = `context.getRegisteredClient().getClientId()`.
+- Mosquitto's JWT plugin will be configured to use this claim as the MQTT username for ACL evaluation.
+- Keep the existing `role` claim logic untouched — it only fires when a principal authority is present (user-based grants).
+
+### 6. Allow `client_credentials` on the token endpoint
+
+`OAuth2AuthorizationServerConfiguration.applyDefaultSecurity` already enables `client_credentials` if the registered client requests it. **No filter chain changes expected** — verify in an integration test (Step 8).
+
+### 7. Configuration
+
+`application.yaml` additions:
+
+```yaml
+app:
+  oidc:
+    device-clients:
+      access-token-ttl-seconds: 3600
+      allowed-scopes: [mqtt:pub, mqtt:sub]
+```
+
+No env vars added — device secrets are generated, not configured.
+
+### 8. Tests
+
+- `DeviceClientControllerTest` (MockMvc, admin & service-to-service auth, validation, 404, idempotent delete).
+- `DeviceClientServiceTest` (secret generation + bcrypt encoding, scope defaults, `client_kind='device'`).
+- `StaticClientSeederTest` (seeds on empty DB, no-op on second run).
+- Extend `OidcFlowIntegrationTest` with a `client_credentials` flow: register device → request token → assert JWT carries `device_id` claim + `mqtt:pub`/`mqtt:sub` scopes → assert signature validates via `/oauth2/jwks`.
+- `FlywayMigrationTest` continues to pass on a fresh DB after adding V5.
+
+---
+
+## Out of scope
+
+- Public RFC 7591 dynamic client registration endpoint — admin API is internal only.
+- Refresh tokens for device clients — devices re-authenticate on token expiry, simpler than rotation.
+- Per-topic scope granularity (`mqtt:pub:terra1/#`) — handled by Mosquitto ACL using `device_id`, not by scopes.
+- Frontend UI — lives elsewhere (calls device-service, not auth-service directly).
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Seeder overwrites manual `psql` edits to SSO clients | Seeder uses `findByClientId` and skips if present. Document that post-bootstrap edits to SSO clients must use `psql` *or* the admin API, not `application.yaml`. |
+| `client_kind` column drifts from grant type | Add an integration test that asserts every `client_credentials`-only client has `client_kind='device'`. |
+| Plaintext secret in HTTP response logs | Add `@JsonIgnore`-style precaution in the controller logging filter; ensure Sentry breadcrumbs don't include response bodies for `/api/v1/clients`. |
+| Long-lived bcrypt cost on Pi | bcrypt strength 10 is fine; profile if device fleet > 50. |
+
+---
+
+## Acceptance
+
+- `curl -u device-service:<secret> -d 'grant_type=client_credentials' .../oauth2/token` for a registered device client returns a JWT containing `device_id` and `scope: "mqtt:pub mqtt:sub"`.
+- `POST /api/v1/clients` followed by `DELETE` removes the client and invalidates outstanding tokens (Mosquitto rejects the JWT after delete + key cache invalidation interval).
+- `GET /api/v1/clients` returns only `client_kind='device'` rows.
+- Existing SSO flows (Grafana login, device-service Swagger SSO) are unchanged.

--- a/docs/SPEC-iot-device-clients.md
+++ b/docs/SPEC-iot-device-clients.md
@@ -158,6 +158,6 @@ No env vars added — device secrets are generated, not configured.
 ## Acceptance
 
 - `curl -u device-service:<secret> -d 'grant_type=client_credentials' .../oauth2/token` for a registered device client returns a JWT containing `device_id` and `scope: "mqtt:pub mqtt:sub"`.
-- `POST /api/v1/clients` followed by `DELETE` removes the client and invalidates outstanding tokens (Mosquitto rejects the JWT after delete + key cache invalidation interval).
+- `POST /api/v1/clients` followed by `DELETE` removes the client; new token requests fail immediately (the AS no longer recognises the `client_id`). JWTs already issued remain valid at Mosquitto until their `exp` (1 h TTL) — immediate revocation of outstanding tokens requires signing-key rotation.
 - `GET /api/v1/clients` returns only `client_kind='device'` rows.
 - Existing SSO flows (Grafana login, device-service Swagger SSO) are unchanged.

--- a/src/main/java/ch/furchert/homelab/auth/AuthServiceApplication.java
+++ b/src/main/java/ch/furchert/homelab/auth/AuthServiceApplication.java
@@ -10,8 +10,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class AuthServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(AuthServiceApplication.class, args);
-	}
+    static void main(String[] args) {
+        SpringApplication.run(AuthServiceApplication.class, args);
+    }
 
 }

--- a/src/main/java/ch/furchert/homelab/auth/config/AuthorizationServerConfig.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/AuthorizationServerConfig.java
@@ -55,7 +55,7 @@ public class AuthorizationServerConfig {
      */
     @Bean
     @Order(1)
-    public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http){
         http
                 .securityMatcher("/oauth2/**", "/.well-known/**", "/userinfo", "/connect/**")
                 .oauth2AuthorizationServer(as -> as
@@ -137,8 +137,9 @@ public class AuthorizationServerConfig {
             boolean isIdToken = "id_token".equals(context.getTokenType().getValue());
             if (!isAccessToken && !isIdToken) return;
 
-            // role claim — user-driven grants only (principal has authorities)
+            // role claim — only emit for ROLE_* authorities (user-driven grants)
             context.getPrincipal().getAuthorities().stream()
+                    .filter(a -> a.getAuthority().startsWith("ROLE_"))
                     .findFirst()
                     .ifPresent(a -> {
                         String role = a.getAuthority().replaceFirst("^ROLE_", "");

--- a/src/main/java/ch/furchert/homelab/auth/config/AuthorizationServerConfig.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/AuthorizationServerConfig.java
@@ -2,6 +2,7 @@ package ch.furchert.homelab.auth.config;
 
 import ch.furchert.homelab.auth.security.OidcUserInfoMapper;
 import ch.furchert.homelab.auth.security.RsaKeyProvider;
+import ch.furchert.homelab.auth.service.ClientKindLookup;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
@@ -19,29 +20,21 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
-import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
-import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
-import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
-import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.time.Duration;
-import java.util.List;
-import java.util.UUID;
 
 @Configuration
 @EnableConfigurationProperties(OidcClientProperties.class)
@@ -51,7 +44,6 @@ public class AuthorizationServerConfig {
     private static final String RSA_KEY_ID = "auth-service-v1";
 
     private final OidcClientProperties oidcClientProperties;
-    private final RsaKeyProperties rsaKeyProperties;
     private final RsaKeyProvider rsaKeyProvider;
     private final OidcUserInfoMapper userInfoMapper;
 
@@ -65,24 +57,24 @@ public class AuthorizationServerConfig {
     @Order(1)
     public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/oauth2/**", "/.well-known/**", "/userinfo", "/connect/**")
-            .oauth2AuthorizationServer(as -> as
-                .oidc(oidc -> oidc
-                    .userInfoEndpoint(userInfo -> userInfo.userInfoMapper(userInfoMapper))
-                    .providerConfigurationEndpoint(Customizer.withDefaults())
-                    .logoutEndpoint(Customizer.withDefaults())
+                .securityMatcher("/oauth2/**", "/.well-known/**", "/userinfo", "/connect/**")
+                .oauth2AuthorizationServer(as -> as
+                        .oidc(oidc -> oidc
+                                .userInfoEndpoint(userInfo -> userInfo.userInfoMapper(userInfoMapper))
+                                .providerConfigurationEndpoint(Customizer.withDefaults())
+                                .logoutEndpoint(Customizer.withDefaults())
+                        )
                 )
-            )
-            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-            )
-            .exceptionHandling(ex -> ex
-                .defaultAuthenticationEntryPointFor(
-                    new LoginUrlAuthenticationEntryPoint("/login"),
-                    new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
+                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )
-            );
+                .exceptionHandling(ex -> ex
+                        .defaultAuthenticationEntryPointFor(
+                                new LoginUrlAuthenticationEntryPoint("/login"),
+                                new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
+                        )
+                );
 
         return http.build();
     }
@@ -103,40 +95,15 @@ public class AuthorizationServerConfig {
         return OAuth2AuthorizationServerConfiguration.jwtDecoder(jwkSource);
     }
 
+    /**
+     * JDBC-backed registered-client repository. SSO clients are seeded from
+     * application.yaml on first boot by {@link StaticClientSeeder}; device
+     * clients are created via the admin API. An empty DB on boot is valid:
+     * the seeder will populate it.
+     */
     @Bean
-    public RegisteredClientRepository registeredClientRepository() {
-        if (oidcClientProperties.getClients().isEmpty()) {
-            throw new IllegalStateException(
-                    "No OIDC clients configured. Set app.oidc.clients in application.yaml.");
-        }
-        List<RegisteredClient> clients = oidcClientProperties.getClients().stream()
-                .map(def -> {
-                    RegisteredClient.Builder builder = RegisteredClient
-                            .withId(UUID.nameUUIDFromBytes(
-                                    def.getClientId().getBytes(StandardCharsets.UTF_8)).toString())
-                            .clientId(def.getClientId())
-                            .clientSecret(def.getClientSecret())
-                            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                            .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                            .scopes(scopes -> scopes.addAll(def.getScopes()))
-                            .redirectUris(uris -> uris.addAll(def.getRedirectUris()))
-                            .clientSettings(ClientSettings.builder()
-                                    .requireAuthorizationConsent(false)
-                                    .requireProofKey(true)
-                                    .build())
-                            .tokenSettings(TokenSettings.builder()
-                                    .accessTokenTimeToLive(Duration.ofMillis(
-                                            rsaKeyProperties.getAccessTokenExpiry()))
-                                    .refreshTokenTimeToLive(Duration.ofMillis(
-                                            rsaKeyProperties.getRefreshTokenExpiry()))
-                                    .authorizationCodeTimeToLive(Duration.ofMinutes(5))
-                                    .build());
-                    def.getPostLogoutRedirectUris().forEach(builder::postLogoutRedirectUri);
-                    return builder.build();
-                })
-                .toList();
-        return new InMemoryRegisteredClientRepository(clients);
+    public RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
+        return new JdbcRegisteredClientRepository(jdbcOperations);
     }
 
     @Bean
@@ -153,19 +120,37 @@ public class AuthorizationServerConfig {
                 .build();
     }
 
+    /**
+     * Adds JWT claims:
+     * <ul>
+     *   <li>{@code role}: stripped of the ROLE_ prefix, taken from the principal's first
+     *       authority. Only fires for user-driven grants (auth_code).</li>
+     *   <li>{@code device_id}: the clientId of the registered client, added ONLY for
+     *       client_credentials access tokens whose client_kind = 'device'. Mosquitto's
+     *       JWT plugin uses this for MQTT ACL evaluation.</li>
+     * </ul>
+     */
     @Bean
-    public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer() {
+    public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer(ClientKindLookup clientKindLookup) {
         return context -> {
             boolean isAccessToken = OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType());
             boolean isIdToken = "id_token".equals(context.getTokenType().getValue());
             if (!isAccessToken && !isIdToken) return;
 
+            // role claim — user-driven grants only (principal has authorities)
             context.getPrincipal().getAuthorities().stream()
                     .findFirst()
                     .ifPresent(a -> {
                         String role = a.getAuthority().replaceFirst("^ROLE_", "");
                         context.getClaims().claim("role", role);
                     });
+
+            // device_id claim — client_credentials access tokens for device clients
+            if (isAccessToken
+                    && AuthorizationGrantType.CLIENT_CREDENTIALS.equals(context.getAuthorizationGrantType())
+                    && clientKindLookup.isDevice(context.getRegisteredClient().getId())) {
+                context.getClaims().claim("device_id", context.getRegisteredClient().getClientId());
+            }
         };
     }
 }

--- a/src/main/java/ch/furchert/homelab/auth/config/OidcClientProperties.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/OidcClientProperties.java
@@ -14,6 +14,7 @@ public class OidcClientProperties {
 
     private String issuer;
     private List<ClientDefinition> clients = new ArrayList<>();
+    private DeviceClientsProperties deviceClients = new DeviceClientsProperties();
 
     @Getter
     @Setter
@@ -23,5 +24,24 @@ public class OidcClientProperties {
         private List<String> redirectUris = new ArrayList<>();
         private List<String> postLogoutRedirectUris = new ArrayList<>();
         private List<String> scopes = new ArrayList<>();
+        /**
+         * OAuth2 grant types the client may use. Defaults to authorization_code +
+         * refresh_token (the existing SSO pattern); the device-service entry adds
+         * client_credentials so it can call the admin API service-to-service.
+         */
+        private List<String> grantTypes = new ArrayList<>(List.of("authorization_code", "refresh_token"));
+    }
+
+    @Getter
+    @Setter
+    public static class DeviceClientsProperties {
+        /**
+         * Access-token TTL applied to newly created device clients.
+         */
+        private long accessTokenTtlSeconds = 3600;
+        /**
+         * Scopes a device client is allowed to request.
+         */
+        private List<String> allowedScopes = new ArrayList<>(List.of("mqtt:pub", "mqtt:sub"));
     }
 }

--- a/src/main/java/ch/furchert/homelab/auth/config/SecurityConfig.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/SecurityConfig.java
@@ -5,9 +5,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
@@ -17,8 +19,12 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     /**
@@ -31,23 +37,26 @@ public class SecurityConfig {
     @Order(2)
     public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/api/v1/**")
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.POST, "/api/v1/users").hasRole("ADMIN")
-                .requestMatchers(HttpMethod.PUT, "/api/v1/users/**").hasRole("ADMIN")
-                .requestMatchers(HttpMethod.DELETE, "/api/v1/users/**").hasRole("ADMIN")
-                .anyRequest().authenticated()
-            )
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            )
-            .oauth2ResourceServer(rs -> rs
-                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
-            )
-            .exceptionHandling(ex -> ex
-                .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
-            )
-            .csrf(csrf -> csrf.ignoringRequestMatchers(request -> true));
+                .securityMatcher("/api/v1/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/**").hasRole("ADMIN")
+                        // /api/v1/clients/** uses method-level @PreAuthorize on the controller
+                        // (role ADMIN OR scope clients:admin). The filter chain only enforces
+                        // authentication; method security enforces the exact rule.
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .oauth2ResourceServer(rs -> rs
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                )
+                .csrf(csrf -> csrf.ignoringRequestMatchers(request -> true));
 
         return http.build();
     }
@@ -60,18 +69,18 @@ public class SecurityConfig {
     @Order(3)
     public SecurityFilterChain loginSecurityFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/login", "/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**")
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/login", "/actuator/health", "/actuator/info").permitAll()
-                .anyRequest().authenticated()
-            )
-            .formLogin(form -> form
-                .loginPage("/login")
-                .permitAll()
-            )
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
-            );
+                .securityMatcher("/login", "/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/login", "/actuator/health", "/actuator/info").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .permitAll()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                );
 
         return http.build();
     }
@@ -100,12 +109,29 @@ public class SecurityConfig {
         return encoder;
     }
 
-    private JwtAuthenticationConverter jwtAuthenticationConverter() {
-        JwtGrantedAuthoritiesConverter authoritiesConverter = new JwtGrantedAuthoritiesConverter();
-        authoritiesConverter.setAuthoritiesClaimName("role");
-        authoritiesConverter.setAuthorityPrefix("ROLE_");
+    /**
+     * Emits both ROLE_* authorities (from the "role" claim used by user JWTs) and
+     * SCOPE_* authorities (from the standard "scope" claim used by client_credentials
+     * tokens). Either converter may return null when the corresponding claim is
+     * absent — both branches are null-guarded.
+     */
+    static JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter scopesConverter = new JwtGrantedAuthoritiesConverter();
+        // default: reads "scope" / "scp", prefix "SCOPE_"
+
+        JwtGrantedAuthoritiesConverter rolesConverter = new JwtGrantedAuthoritiesConverter();
+        rolesConverter.setAuthoritiesClaimName("role");
+        rolesConverter.setAuthorityPrefix("ROLE_");
+
         JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
-        converter.setJwtGrantedAuthoritiesConverter(authoritiesConverter);
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            Collection<GrantedAuthority> authorities = new ArrayList<>();
+            Collection<GrantedAuthority> scopes = scopesConverter.convert(jwt);
+            Collection<GrantedAuthority> roles = rolesConverter.convert(jwt);
+            if (scopes != null) authorities.addAll(scopes);
+            if (roles != null) authorities.addAll(roles);
+            return authorities;
+        });
         return converter;
     }
 }

--- a/src/main/java/ch/furchert/homelab/auth/config/SecurityConfig.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/SecurityConfig.java
@@ -27,6 +27,9 @@ import java.util.Collection;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private static final String LOGIN_URL = "/login";
+    private static final String ADMIN = "ADMIN";
+
     /**
      * Chain 2: stateless resource-server for the admin REST API.
      * CSRF is not required: Bearer tokens are sent via the Authorization header,
@@ -35,13 +38,13 @@ public class SecurityConfig {
      */
     @Bean
     @Order(2)
-    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) {
         http
                 .securityMatcher("/api/v1/**")
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.POST, "/api/v1/users").hasRole("ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/**").hasRole("ADMIN")
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/users").hasRole(ADMIN)
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/**").hasRole(ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/**").hasRole(ADMIN)
                         // /api/v1/clients/** uses method-level @PreAuthorize on the controller
                         // (role ADMIN OR scope clients:admin). The filter chain only enforces
                         // authentication; method security enforces the exact rule.
@@ -67,15 +70,15 @@ public class SecurityConfig {
      */
     @Bean
     @Order(3)
-    public SecurityFilterChain loginSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain loginSecurityFilterChain(HttpSecurity http) {
         http
-                .securityMatcher("/login", "/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**")
+                .securityMatcher(LOGIN_URL, "/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**")
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login", "/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers(LOGIN_URL, "/actuator/health", "/actuator/info").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form
-                        .loginPage("/login")
+                        .loginPage(LOGIN_URL)
                         .permitAll()
                 )
                 .sessionManagement(session -> session
@@ -91,7 +94,7 @@ public class SecurityConfig {
      */
     @Bean
     @Order(999)
-    public SecurityFilterChain catchAllSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain catchAllSecurityFilterChain(HttpSecurity http) {
         http.authorizeHttpRequests(auth -> auth.anyRequest().denyAll());
         return http.build();
     }
@@ -128,8 +131,8 @@ public class SecurityConfig {
             Collection<GrantedAuthority> authorities = new ArrayList<>();
             Collection<GrantedAuthority> scopes = scopesConverter.convert(jwt);
             Collection<GrantedAuthority> roles = rolesConverter.convert(jwt);
-            if (scopes != null) authorities.addAll(scopes);
-            if (roles != null) authorities.addAll(roles);
+            authorities.addAll(scopes);
+            authorities.addAll(roles);
             return authorities;
         });
         return converter;

--- a/src/main/java/ch/furchert/homelab/auth/config/StaticClientSeeder.java
+++ b/src/main/java/ch/furchert/homelab/auth/config/StaticClientSeeder.java
@@ -1,0 +1,93 @@
+package ch.furchert.homelab.auth.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * Seeds the SSO clients from application.yaml into oauth2_registered_client on
+ * startup, AFTER Flyway has run and BEFORE HTTP traffic is served. Idempotent:
+ * each client is skipped if it already exists (by client_id). YAML is therefore
+ * a bootstrap source only — post-bootstrap edits must go through psql or the
+ * (future) admin API.
+ * <p>
+ * Secret handling: YAML values are passed through verbatim — they MUST already
+ * carry a DelegatingPasswordEncoder prefix ({noop}/{bcrypt}/...) per the
+ * application.yaml comment on each client. Re-encoding a {bcrypt} value would
+ * double-hash and silently break SSO logins.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StaticClientSeeder implements ApplicationRunner {
+
+    private final OidcClientProperties properties;
+    private final RsaKeyProperties rsaKeyProperties;
+    private final RegisteredClientRepository registeredClientRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        int seeded = 0;
+        for (OidcClientProperties.ClientDefinition def : properties.getClients()) {
+            if (registeredClientRepository.findByClientId(def.getClientId()) != null) {
+                log.debug("SSO client '{}' already present in DB; skipping seed", def.getClientId());
+                continue;
+            }
+            RegisteredClient client = buildRegisteredClient(def);
+            registeredClientRepository.save(client);
+            seeded++;
+            log.info("Seeded SSO client '{}' (id={})", def.getClientId(), client.getId());
+        }
+
+        Integer total = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client", Integer.class);
+        long totalCount = total == null ? 0L : total;
+        if (totalCount == 0) {
+            log.warn("No clients in oauth2_registered_client after seeding — "
+                    + "this auth-service instance cannot serve any OAuth2 flow");
+        } else {
+            log.info("StaticClientSeeder finished: seeded {} new clients of {} configured; total in DB: {}",
+                    seeded, properties.getClients().size(), totalCount);
+        }
+    }
+
+    private RegisteredClient buildRegisteredClient(OidcClientProperties.ClientDefinition def) {
+        RegisteredClient.Builder builder = RegisteredClient
+                .withId(UUID.nameUUIDFromBytes(
+                        def.getClientId().getBytes(StandardCharsets.UTF_8)).toString())
+                .clientId(def.getClientId())
+                .clientSecret(def.getClientSecret())
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .scopes(scopes -> scopes.addAll(def.getScopes()))
+                .redirectUris(uris -> uris.addAll(def.getRedirectUris()))
+                .clientSettings(ClientSettings.builder()
+                        .requireAuthorizationConsent(false)
+                        .requireProofKey(true)
+                        .build())
+                .tokenSettings(TokenSettings.builder()
+                        .accessTokenTimeToLive(Duration.ofMillis(rsaKeyProperties.getAccessTokenExpiry()))
+                        .refreshTokenTimeToLive(Duration.ofMillis(rsaKeyProperties.getRefreshTokenExpiry()))
+                        .authorizationCodeTimeToLive(Duration.ofMinutes(5))
+                        .build());
+
+        for (String grant : def.getGrantTypes()) {
+            builder.authorizationGrantType(new AuthorizationGrantType(grant));
+        }
+        def.getPostLogoutRedirectUris().forEach(builder::postLogoutRedirectUri);
+        return builder.build();
+    }
+}

--- a/src/main/java/ch/furchert/homelab/auth/controller/DeviceClientController.java
+++ b/src/main/java/ch/furchert/homelab/auth/controller/DeviceClientController.java
@@ -1,0 +1,58 @@
+package ch.furchert.homelab.auth.controller;
+
+import ch.furchert.homelab.auth.dto.CreateDeviceClientRequest;
+import ch.furchert.homelab.auth.dto.DeviceClientCreatedResponse;
+import ch.furchert.homelab.auth.dto.DeviceClientResponse;
+import ch.furchert.homelab.auth.service.DeviceClientService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Admin API for IoT device OAuth2 clients. Authorization rule:
+ * <ul>
+ *   <li>{@code hasRole('ADMIN')} — human administrator JWT (auth_code flow).</li>
+ *   <li>{@code hasAuthority('SCOPE_clients:admin')} — service-to-service calls from
+ *       device-service (client_credentials flow with the clients:admin scope).</li>
+ * </ul>
+ * <p>
+ * Security note: the create() response body contains a plaintext client secret
+ * returned exactly once. Do not log the response body. Sentry is configured
+ * (application.yaml) without HTTP body capture, so default breadcrumbs are safe.
+ */
+@RestController
+@RequestMapping("/api/v1/clients")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN') or hasAuthority('SCOPE_clients:admin')")
+public class DeviceClientController {
+
+    private final DeviceClientService deviceClientService;
+
+    @PostMapping
+    public ResponseEntity<DeviceClientCreatedResponse> create(@Valid @RequestBody CreateDeviceClientRequest req) {
+        DeviceClientCreatedResponse created =
+                deviceClientService.create(req.clientId(), req.description());
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping
+    public List<DeviceClientResponse> list() {
+        return deviceClientService.list();
+    }
+
+    @GetMapping("/{clientId}")
+    public DeviceClientResponse get(@PathVariable String clientId) {
+        return deviceClientService.get(clientId);
+    }
+
+    @DeleteMapping("/{clientId}")
+    public ResponseEntity<Void> delete(@PathVariable String clientId) {
+        deviceClientService.delete(clientId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/ch/furchert/homelab/auth/controller/UserController.java
+++ b/src/main/java/ch/furchert/homelab/auth/controller/UserController.java
@@ -29,14 +29,14 @@ public class UserController {
 
     @GetMapping("/{id}")
     public ResponseEntity<UserResponse> getUser(@PathVariable Long id,
-                                                 @AuthenticationPrincipal(expression = "subject") String username) {
+                                                @AuthenticationPrincipal(expression = "subject") String username) {
         boolean isAdmin = isAdmin();
         return ResponseEntity.ok(userService.getUser(id, username, isAdmin));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<UserResponse> updateUser(@PathVariable Long id,
-                                                    @Valid @RequestBody UpdateUserRequest request) {
+                                                   @Valid @RequestBody UpdateUserRequest request) {
         return ResponseEntity.ok(userService.updateUser(id, request));
     }
 
@@ -48,8 +48,8 @@ public class UserController {
 
     @PostMapping("/{id}/reset-password")
     public ResponseEntity<Void> resetPassword(@PathVariable Long id,
-                                               @Valid @RequestBody ResetPasswordRequest request,
-                                               @AuthenticationPrincipal(expression = "subject") String username) {
+                                              @Valid @RequestBody ResetPasswordRequest request,
+                                              @AuthenticationPrincipal(expression = "subject") String username) {
         boolean isAdmin = isAdmin();
         userService.resetPassword(id, request, username, isAdmin);
         return ResponseEntity.noContent().build();

--- a/src/main/java/ch/furchert/homelab/auth/dto/CreateDeviceClientRequest.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/CreateDeviceClientRequest.java
@@ -1,0 +1,18 @@
+package ch.furchert.homelab.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Body for POST /api/v1/clients. The clientId pattern matches MQTT username rules
+ * (lowercase alphanumerics + dash, 3..32 chars).
+ */
+public record CreateDeviceClientRequest(
+        @NotBlank
+        @Pattern(regexp = "[a-z0-9-]{3,32}", message = "clientId must match [a-z0-9-]{3,32}")
+        String clientId,
+        @Size(max = 200)
+        String description
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/dto/CreateUserRequest.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/CreateUserRequest.java
@@ -10,4 +10,5 @@ public record CreateUserRequest(
         @NotBlank @Email @Size(max = 100) String email,
         @NotBlank @Size(min = 8, max = 72) String password,
         Role role
-) {}
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/dto/DeviceClientCreatedResponse.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/DeviceClientCreatedResponse.java
@@ -1,0 +1,16 @@
+package ch.furchert.homelab.auth.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Returned from POST /api/v1/clients. Contains the plaintext client secret —
+ * shown once and never persisted in clear. Never log this response body.
+ */
+public record DeviceClientCreatedResponse(
+        String clientId,
+        String clientSecret,
+        List<String> scopes,
+        Instant createdAt
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/dto/DeviceClientResponse.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/DeviceClientResponse.java
@@ -1,0 +1,12 @@
+package ch.furchert.homelab.auth.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record DeviceClientResponse(
+        String clientId,
+        String description,
+        Instant createdAt,
+        List<String> scopes
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/dto/ResetPasswordRequest.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/ResetPasswordRequest.java
@@ -6,4 +6,5 @@ import jakarta.validation.constraints.Size;
 public record ResetPasswordRequest(
         String currentPassword,
         @NotBlank @Size(min = 8, max = 72) String newPassword
-) {}
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/dto/UpdateUserRequest.java
+++ b/src/main/java/ch/furchert/homelab/auth/dto/UpdateUserRequest.java
@@ -10,4 +10,5 @@ public record UpdateUserRequest(
         @Email @Size(max = 100) String email,
         Role role,
         @Pattern(regexp = "ACTIVE|INACTIVE") String status
-) {}
+) {
+}

--- a/src/main/java/ch/furchert/homelab/auth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ch/furchert/homelab/auth/exception/GlobalExceptionHandler.java
@@ -5,7 +5,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -40,6 +42,17 @@ public class GlobalExceptionHandler {
                 .body(errorBody(HttpStatus.UNAUTHORIZED, "Unauthorized", null));
     }
 
+    /**
+     * @PreAuthorize failures raise AuthorizationDeniedException; legacy access
+     * decisions raise AccessDeniedException. Both must return 403 — otherwise
+     * the catch-all generic handler below maps them to 500.
+     */
+    @ExceptionHandler({AuthorizationDeniedException.class, AccessDeniedException.class})
+    public ResponseEntity<Map<String, Object>> handleAuthorizationDenied(RuntimeException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(errorBody(HttpStatus.FORBIDDEN, "Forbidden", null));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.badRequest().body(errorBody(HttpStatus.BAD_REQUEST, ex.getMessage(), null));
@@ -49,6 +62,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(errorBody(HttpStatus.NOT_FOUND, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler(ResourceConflictException.class)
+    public ResponseEntity<Map<String, Object>> handleConflict(ResourceConflictException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(errorBody(HttpStatus.CONFLICT, ex.getMessage(), null));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/ch/furchert/homelab/auth/exception/ResourceConflictException.java
+++ b/src/main/java/ch/furchert/homelab/auth/exception/ResourceConflictException.java
@@ -1,0 +1,8 @@
+package ch.furchert.homelab.auth.exception;
+
+public class ResourceConflictException extends RuntimeException {
+
+    public ResourceConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ch/furchert/homelab/auth/security/OidcUserInfoMapper.java
+++ b/src/main/java/ch/furchert/homelab/auth/security/OidcUserInfoMapper.java
@@ -23,13 +23,13 @@ public class OidcUserInfoMapper implements Function<OidcUserInfoAuthenticationCo
         String username = authorization.getPrincipalName();
 
         User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
 
         return OidcUserInfo.builder()
-            .subject(user.getUsername())
-            .email(user.getEmail())
-            .claim("preferred_username", user.getUsername())
-            .claim("role", user.getRole().name())
-            .build();
+                .subject(user.getUsername())
+                .email(user.getEmail())
+                .claim("preferred_username", user.getUsername())
+                .claim("role", user.getRole().name())
+                .build();
     }
 }

--- a/src/main/java/ch/furchert/homelab/auth/service/ClientKindLookup.java
+++ b/src/main/java/ch/furchert/homelab/auth/service/ClientKindLookup.java
@@ -1,0 +1,56 @@
+package ch.furchert.homelab.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory cache for the client_kind column of oauth2_registered_client.
+ * <p>
+ * Used by the JWT token customizer to decide whether to emit a device_id claim
+ * on client_credentials access tokens. The cache is per-JVM and assumes a single
+ * auth-service replica. Manual psql edits to client_kind require a service
+ * restart to be picked up (documented in OPERATIONS.md).
+ * <p>
+ * Default-deny: unknown ids or absent client_kind values are treated as "not a
+ * device client" so the device_id claim is omitted.
+ */
+@Service
+@RequiredArgsConstructor
+public class ClientKindLookup {
+
+    static final String DEVICE = "device";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>();
+
+    /**
+     * @param registeredClientId the PK from oauth2_registered_client.id
+     * @return the client_kind value, or null if the row does not exist
+     */
+    public String lookup(String registeredClientId) {
+        return cache.computeIfAbsent(registeredClientId, this::loadFromDb);
+    }
+
+    public boolean isDevice(String registeredClientId) {
+        return DEVICE.equals(lookup(registeredClientId));
+    }
+
+    public void invalidate(String registeredClientId) {
+        cache.remove(registeredClientId);
+    }
+
+    private String loadFromDb(String registeredClientId) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT client_kind FROM oauth2_registered_client WHERE id = ?",
+                    String.class,
+                    registeredClientId);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/ch/furchert/homelab/auth/service/ClientKindLookup.java
+++ b/src/main/java/ch/furchert/homelab/auth/service/ClientKindLookup.java
@@ -49,7 +49,7 @@ public class ClientKindLookup {
                     "SELECT client_kind FROM oauth2_registered_client WHERE id = ?",
                     String.class,
                     registeredClientId);
-        } catch (EmptyResultDataAccessException e) {
+        } catch (EmptyResultDataAccessException _) {
             return null;
         }
     }

--- a/src/main/java/ch/furchert/homelab/auth/service/DeviceClientService.java
+++ b/src/main/java/ch/furchert/homelab/auth/service/DeviceClientService.java
@@ -1,0 +1,175 @@
+package ch.furchert.homelab.auth.service;
+
+import ch.furchert.homelab.auth.config.OidcClientProperties;
+import ch.furchert.homelab.auth.dto.DeviceClientCreatedResponse;
+import ch.furchert.homelab.auth.dto.DeviceClientResponse;
+import ch.furchert.homelab.auth.exception.ResourceConflictException;
+import ch.furchert.homelab.auth.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Lifecycle of IoT device OAuth2 clients (client_kind = 'device'). Methods are
+ * transactional so the side-write to the client_kind column happens atomically
+ * with RegisteredClientRepository.save().
+ * <p>
+ * Security note: create() returns the plaintext client secret exactly once.
+ * Callers must surface it to the operator and never log it.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeviceClientService {
+
+    static final String CLIENT_KIND_DEVICE = "device";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String BCRYPT_PREFIX = "{bcrypt}";
+
+    private final RegisteredClientRepository registeredClientRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final PasswordEncoder passwordEncoder;
+    private final ClientKindLookup clientKindLookup;
+    private final OidcClientProperties properties;
+
+    @Transactional
+    public DeviceClientCreatedResponse create(String clientId, String description) {
+        if (registeredClientRepository.findByClientId(clientId) != null) {
+            throw new ResourceConflictException("Client '" + clientId + "' already exists");
+        }
+
+        String plaintextSecret = generateSecret();
+        String hashedSecret = passwordEncoder.encode(plaintextSecret);
+        if (!hashedSecret.startsWith(BCRYPT_PREFIX)) {
+            // DelegatingPasswordEncoder must emit a {bcrypt} prefix for the BCrypt
+            // delegate to match on /oauth2/token authentication. Fail-fast to avoid
+            // silently breaking the device client (memory: feedback_oidc_secret_prefix).
+            throw new IllegalStateException(
+                    "PasswordEncoder did not emit a {bcrypt} prefix; refusing to persist device client");
+        }
+
+        List<String> scopes = properties.getDeviceClients().getAllowedScopes();
+        Duration ttl = Duration.ofSeconds(properties.getDeviceClients().getAccessTokenTtlSeconds());
+
+        String id = UUID.randomUUID().toString();
+        Instant now = Instant.now();
+        RegisteredClient client = RegisteredClient.withId(id)
+                .clientId(clientId)
+                .clientIdIssuedAt(now)
+                .clientName(description == null ? clientId : description)
+                .clientSecret(hashedSecret)
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .scopes(s -> s.addAll(scopes))
+                .clientSettings(ClientSettings.builder()
+                        .requireProofKey(false)
+                        .requireAuthorizationConsent(false)
+                        .build())
+                .tokenSettings(TokenSettings.builder()
+                        .accessTokenTimeToLive(ttl)
+                        .build())
+                .build();
+
+        registeredClientRepository.save(client);
+        jdbcTemplate.update(
+                "UPDATE oauth2_registered_client SET client_kind = ? WHERE id = ?",
+                CLIENT_KIND_DEVICE, id);
+        clientKindLookup.invalidate(id);
+
+        log.info("Created device client '{}'", clientId);
+        return new DeviceClientCreatedResponse(clientId, plaintextSecret, scopes, now);
+    }
+
+    public List<DeviceClientResponse> list() {
+        return jdbcTemplate.query(
+                "SELECT client_id, client_name, client_id_issued_at, scopes "
+                        + "FROM oauth2_registered_client WHERE client_kind = ? "
+                        + "ORDER BY client_id_issued_at DESC",
+                (rs, rowNum) -> new DeviceClientResponse(
+                        rs.getString("client_id"),
+                        rs.getString("client_name"),
+                        rs.getTimestamp("client_id_issued_at").toInstant(),
+                        splitScopes(rs.getString("scopes"))),
+                CLIENT_KIND_DEVICE);
+    }
+
+    public DeviceClientResponse get(String clientId) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT client_id, client_name, client_id_issued_at, scopes "
+                            + "FROM oauth2_registered_client "
+                            + "WHERE client_kind = ? AND client_id = ?",
+                    (rs, rowNum) -> new DeviceClientResponse(
+                            rs.getString("client_id"),
+                            rs.getString("client_name"),
+                            rs.getTimestamp("client_id_issued_at").toInstant(),
+                            splitScopes(rs.getString("scopes"))),
+                    CLIENT_KIND_DEVICE, clientId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new ResourceNotFoundException("Device client '" + clientId + "' not found");
+        }
+    }
+
+    /**
+     * Idempotent: returns silently if the device client does not exist OR is an
+     * SSO client. The client_kind='device' guard on the initial SELECT prevents
+     * a DELETE /api/v1/clients/grafana from wiping any oauth2_authorization rows
+     * for the grafana SSO client.
+     */
+    @Transactional
+    public void delete(String clientId) {
+        String id;
+        try {
+            id = jdbcTemplate.queryForObject(
+                    "SELECT id FROM oauth2_registered_client "
+                            + "WHERE client_id = ? AND client_kind = ?",
+                    String.class, clientId, CLIENT_KIND_DEVICE);
+        } catch (EmptyResultDataAccessException e) {
+            return;
+        }
+        if (id == null) {
+            return;
+        }
+
+        jdbcTemplate.update(
+                "DELETE FROM oauth2_authorization WHERE registered_client_id = ?", id);
+        jdbcTemplate.update(
+                "DELETE FROM oauth2_authorization_consent WHERE registered_client_id = ?", id);
+        jdbcTemplate.update(
+                "DELETE FROM oauth2_registered_client WHERE id = ?", id);
+        clientKindLookup.invalidate(id);
+        log.info("Deleted device client '{}'", clientId);
+    }
+
+    private static String generateSecret() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static List<String> splitScopes(String csv) {
+        if (csv == null || csv.isBlank()) return List.of();
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/src/main/java/ch/furchert/homelab/auth/service/DeviceClientService.java
+++ b/src/main/java/ch/furchert/homelab/auth/service/DeviceClientService.java
@@ -58,6 +58,7 @@ public class DeviceClientService {
 
         String plaintextSecret = generateSecret();
         String hashedSecret = passwordEncoder.encode(plaintextSecret);
+        assert hashedSecret != null;
         if (!hashedSecret.startsWith(BCRYPT_PREFIX)) {
             // DelegatingPasswordEncoder must emit a {bcrypt} prefix for the BCrypt
             // delegate to match on /oauth2/token authentication. Fail-fast to avoid
@@ -123,7 +124,7 @@ public class DeviceClientService {
                             rs.getTimestamp("client_id_issued_at").toInstant(),
                             splitScopes(rs.getString("scopes"))),
                     CLIENT_KIND_DEVICE, clientId);
-        } catch (EmptyResultDataAccessException e) {
+        } catch (EmptyResultDataAccessException _) {
             throw new ResourceNotFoundException("Device client '" + clientId + "' not found");
         }
     }
@@ -142,7 +143,7 @@ public class DeviceClientService {
                     "SELECT id FROM oauth2_registered_client "
                             + "WHERE client_id = ? AND client_kind = ?",
                     String.class, clientId, CLIENT_KIND_DEVICE);
-        } catch (EmptyResultDataAccessException e) {
+        } catch (EmptyResultDataAccessException _) {
             return;
         }
         if (id == null) {

--- a/src/main/java/ch/furchert/homelab/auth/service/TokenCleanupScheduler.java
+++ b/src/main/java/ch/furchert/homelab/auth/service/TokenCleanupScheduler.java
@@ -21,34 +21,34 @@ public class TokenCleanupScheduler {
         // 2. All expires_at columns are NULL (abandoned/in-progress flow) AND the authorization was
         //    created more than 24 hours ago — allowing time for user interaction before cleanup.
         jdbcTemplate.update("""
-            DELETE FROM oauth2_authorization
-            WHERE (
-                (
-                    refresh_token_expires_at          IS NOT NULL
-                    OR access_token_expires_at        IS NOT NULL
-                    OR authorization_code_expires_at  IS NOT NULL
-                    OR oidc_id_token_expires_at       IS NOT NULL
-                    OR user_code_expires_at           IS NOT NULL
-                    OR device_code_expires_at         IS NOT NULL
+                DELETE FROM oauth2_authorization
+                WHERE (
+                    (
+                        refresh_token_expires_at          IS NOT NULL
+                        OR access_token_expires_at        IS NOT NULL
+                        OR authorization_code_expires_at  IS NOT NULL
+                        OR oidc_id_token_expires_at       IS NOT NULL
+                        OR user_code_expires_at           IS NOT NULL
+                        OR device_code_expires_at         IS NOT NULL
+                    )
+                    AND GREATEST(
+                        COALESCE(refresh_token_expires_at,           to_timestamp(0)),
+                        COALESCE(access_token_expires_at,            to_timestamp(0)),
+                        COALESCE(authorization_code_expires_at,      to_timestamp(0)),
+                        COALESCE(oidc_id_token_expires_at,           to_timestamp(0)),
+                        COALESCE(user_code_expires_at,               to_timestamp(0)),
+                        COALESCE(device_code_expires_at,             to_timestamp(0))
+                    ) < NOW()
                 )
-                AND GREATEST(
-                    COALESCE(refresh_token_expires_at,           to_timestamp(0)),
-                    COALESCE(access_token_expires_at,            to_timestamp(0)),
-                    COALESCE(authorization_code_expires_at,      to_timestamp(0)),
-                    COALESCE(oidc_id_token_expires_at,           to_timestamp(0)),
-                    COALESCE(user_code_expires_at,               to_timestamp(0)),
-                    COALESCE(device_code_expires_at,             to_timestamp(0))
-                ) < NOW()
-            )
-            OR (
-                refresh_token_expires_at          IS NULL
-                AND access_token_expires_at       IS NULL
-                AND authorization_code_expires_at IS NULL
-                AND oidc_id_token_expires_at      IS NULL
-                AND user_code_expires_at          IS NULL
-                AND device_code_expires_at        IS NULL
-                AND authorization_code_issued_at  < NOW() - INTERVAL '24 hours'
-            )
-            """);
+                OR (
+                    refresh_token_expires_at          IS NULL
+                    AND access_token_expires_at       IS NULL
+                    AND authorization_code_expires_at IS NULL
+                    AND oidc_id_token_expires_at      IS NULL
+                    AND user_code_expires_at          IS NULL
+                    AND device_code_expires_at        IS NULL
+                    AND authorization_code_issued_at  < NOW() - INTERVAL '24 hours'
+                )
+                """);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,10 @@ app:
     refresh-token-expiry: 604800000
   oidc:
     issuer: https://auth.furchert.ch
+    # Defaults applied when an admin creates a new IoT device client through /api/v1/clients.
+    device-clients:
+      access-token-ttl-seconds: 3600
+      allowed-scopes: [ mqtt:pub, mqtt:sub ]
     clients:
       - client-id: grafana
         # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
@@ -38,7 +42,7 @@ app:
           - https://grafana.furchert.ch/login/generic_oauth
         post-logout-redirect-uris:
           - https://grafana.furchert.ch
-        scopes: [openid, profile, email]
+        scopes: [ openid, profile, email ]
       - client-id: homeassistant
         # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
         client-secret: "${HA_CLIENT_SECRET}"
@@ -46,7 +50,7 @@ app:
           - https://ha.furchert.ch/auth/oidc/callback
         post-logout-redirect-uris:
           - https://ha.furchert.ch
-        scopes: [openid, profile, email]
+        scopes: [ openid, profile, email ]
       - client-id: device-service
         # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
         client-secret: "${DEVICE_SERVICE_CLIENT_SECRET}"
@@ -55,7 +59,11 @@ app:
           - http://localhost:8081/login/oauth2/code/device-service
         post-logout-redirect-uris:
           - https://device.furchert.ch
-        scopes: [openid, profile, email]
+        scopes: [ openid, profile, email, "clients:admin" ]
+        # device-service has both auth_code (for human admin SSO) and client_credentials
+        # (for service-to-service calls to /api/v1/clients). PKCE is only enforced
+        # on the auth_code endpoint, so requireProofKey=true is harmless for the S2S half.
+        grant-types: [ authorization_code, refresh_token, client_credentials ]
       - client-id: n8n
         # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
         client-secret: "${N8N_CLIENT_SECRET}"
@@ -63,7 +71,7 @@ app:
           - https://n8n.furchert.ch/rest/sso/oidc/callback
         post-logout-redirect-uris:
           - https://n8n.furchert.ch
-        scopes: [openid, profile, email]
+        scopes: [ openid, profile, email ]
       - client-id: litellm
         # The env var must include the Spring Security {id} prefix, e.g. "{noop}secret" or "{bcrypt}$2a$...".
         client-secret: "${LITELLM_CLIENT_SECRET}"
@@ -71,7 +79,7 @@ app:
           - https://ai.furchert.ch/sso/callback
         post-logout-redirect-uris:
           - https://ai.furchert.ch
-        scopes: [openid, profile, email]
+        scopes: [ openid, profile, email ]
 
 management:
   endpoints:

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,21 +1,62 @@
-CREATE TABLE IF NOT EXISTS users (
-    id            BIGSERIAL    PRIMARY KEY,
-    username      VARCHAR(50)  NOT NULL UNIQUE,
-    email         VARCHAR(100) NOT NULL UNIQUE,
-    password_hash VARCHAR(72)  NOT NULL,
-    role          VARCHAR(10)  NOT NULL DEFAULT 'USER',
-    status        VARCHAR(10)  NOT NULL DEFAULT 'ACTIVE',
-    created_at    TIMESTAMP    NOT NULL DEFAULT NOW(),
-    updated_at    TIMESTAMP    NOT NULL DEFAULT NOW()
-);
+CREATE TABLE IF NOT EXISTS users
+(
+    id
+    BIGSERIAL
+    PRIMARY
+    KEY,
+    username
+    VARCHAR
+(
+    50
+) NOT NULL UNIQUE,
+    email VARCHAR
+(
+    100
+) NOT NULL UNIQUE,
+    password_hash VARCHAR
+(
+    72
+) NOT NULL,
+    role VARCHAR
+(
+    10
+) NOT NULL DEFAULT 'USER',
+    status VARCHAR
+(
+    10
+) NOT NULL DEFAULT 'ACTIVE',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW
+(
+),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW
+(
+)
+    );
 
-CREATE TABLE IF NOT EXISTS refresh_tokens (
-    id         BIGSERIAL     PRIMARY KEY,
-    user_id    BIGINT        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    token      VARCHAR(2048) NOT NULL UNIQUE,
-    expires_at TIMESTAMP     NOT NULL,
-    created_at TIMESTAMP     NOT NULL DEFAULT NOW()
-);
+CREATE TABLE IF NOT EXISTS refresh_tokens
+(
+    id
+    BIGSERIAL
+    PRIMARY
+    KEY,
+    user_id
+    BIGINT
+    NOT
+    NULL
+    REFERENCES
+    users
+(
+    id
+) ON DELETE CASCADE,
+    token VARCHAR
+(
+    2048
+) NOT NULL UNIQUE,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW
+(
+)
+    );
 
 CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens(user_id);
-CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token   ON refresh_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token ON refresh_tokens(token);

--- a/src/main/resources/db/migration/V2__timestamps_to_timestamptz_and_fixes.sql
+++ b/src/main/resources/db/migration/V2__timestamps_to_timestamptz_and_fixes.sql
@@ -1,4 +1,5 @@
-SET timezone = 'UTC';
+SET
+timezone = 'UTC';
 
 -- Convert all timestamp columns to timestamptz for correct timezone handling
 ALTER TABLE users ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';

--- a/src/main/resources/db/migration/V3__oauth2_authorization_schema.sql
+++ b/src/main/resources/db/migration/V3__oauth2_authorization_schema.sql
@@ -1,47 +1,86 @@
 -- Spring Authorization Server JDBC schema
 -- Column types: text for token values (no length limit), timestamp with time zone (consistent with V1/V2)
 
-CREATE TABLE IF NOT EXISTS oauth2_authorization (
-    id                                varchar(100)             NOT NULL,
-    registered_client_id              varchar(100)             NOT NULL,
-    principal_name                    varchar(200)             NOT NULL,
-    authorization_grant_type          varchar(100)             NOT NULL,
-    authorized_scopes                 varchar(1000)            DEFAULT NULL,
-    attributes                        text                     DEFAULT NULL,
-    state                             varchar(500)             DEFAULT NULL,
-    authorization_code_value          text                     DEFAULT NULL,
-    authorization_code_issued_at      timestamp with time zone DEFAULT NULL,
-    authorization_code_expires_at     timestamp with time zone DEFAULT NULL,
-    authorization_code_metadata       text                     DEFAULT NULL,
-    access_token_value                text                     DEFAULT NULL,
-    access_token_issued_at            timestamp with time zone DEFAULT NULL,
-    access_token_expires_at           timestamp with time zone DEFAULT NULL,
-    access_token_metadata             text                     DEFAULT NULL,
-    access_token_type                 varchar(100)             DEFAULT NULL,
-    access_token_scopes               varchar(1000)            DEFAULT NULL,
-    oidc_id_token_value               text                     DEFAULT NULL,
-    oidc_id_token_issued_at           timestamp with time zone DEFAULT NULL,
-    oidc_id_token_expires_at          timestamp with time zone DEFAULT NULL,
-    oidc_id_token_metadata            text                     DEFAULT NULL,
-    oidc_id_token_claims              text                     DEFAULT NULL,
-    refresh_token_value               text                     DEFAULT NULL,
-    refresh_token_issued_at           timestamp with time zone DEFAULT NULL,
-    refresh_token_expires_at          timestamp with time zone DEFAULT NULL,
-    refresh_token_metadata            text                     DEFAULT NULL,
-    user_code_value                   text                     DEFAULT NULL,
-    user_code_issued_at               timestamp with time zone DEFAULT NULL,
-    user_code_expires_at              timestamp with time zone DEFAULT NULL,
-    user_code_metadata                text                     DEFAULT NULL,
-    device_code_value                 text                     DEFAULT NULL,
-    device_code_issued_at             timestamp with time zone DEFAULT NULL,
-    device_code_expires_at            timestamp with time zone DEFAULT NULL,
-    device_code_metadata              text                     DEFAULT NULL,
-    PRIMARY KEY (id)
-);
+CREATE TABLE IF NOT EXISTS oauth2_authorization
+(
+    id
+    varchar
+(
+    100
+) NOT NULL,
+    registered_client_id varchar
+(
+    100
+) NOT NULL,
+    principal_name varchar
+(
+    200
+) NOT NULL,
+    authorization_grant_type varchar
+(
+    100
+) NOT NULL,
+    authorized_scopes varchar
+(
+    1000
+) DEFAULT NULL,
+    attributes text DEFAULT NULL,
+    state varchar
+(
+    500
+) DEFAULT NULL,
+    authorization_code_value text DEFAULT NULL,
+    authorization_code_issued_at timestamp with time zone DEFAULT NULL,
+    authorization_code_expires_at timestamp with time zone DEFAULT NULL,
+    authorization_code_metadata text DEFAULT NULL,
+    access_token_value text DEFAULT NULL,
+    access_token_issued_at timestamp with time zone DEFAULT NULL,
+    access_token_expires_at timestamp with time zone DEFAULT NULL,
+                                          access_token_metadata text DEFAULT NULL,
+                                          access_token_type varchar (100) DEFAULT NULL,
+    access_token_scopes varchar
+(
+    1000
+) DEFAULT NULL,
+    oidc_id_token_value text DEFAULT NULL,
+    oidc_id_token_issued_at timestamp with time zone DEFAULT NULL,
+    oidc_id_token_expires_at timestamp with time zone DEFAULT NULL,
+    oidc_id_token_metadata text DEFAULT NULL,
+    oidc_id_token_claims text DEFAULT NULL,
+    refresh_token_value text DEFAULT NULL,
+    refresh_token_issued_at timestamp with time zone DEFAULT NULL,
+    refresh_token_expires_at timestamp with time zone DEFAULT NULL,
+    refresh_token_metadata text DEFAULT NULL,
+    user_code_value text DEFAULT NULL,
+    user_code_issued_at timestamp with time zone DEFAULT NULL,
+    user_code_expires_at timestamp with time zone DEFAULT NULL,
+    user_code_metadata text DEFAULT NULL,
+    device_code_value text DEFAULT NULL,
+    device_code_issued_at timestamp with time zone DEFAULT NULL,
+    device_code_expires_at timestamp
+                                      with time zone DEFAULT NULL,
+                                          device_code_metadata text DEFAULT NULL,
+                                          PRIMARY KEY (id)
+    );
 
-CREATE TABLE IF NOT EXISTS oauth2_authorization_consent (
-    registered_client_id varchar(100)  NOT NULL,
-    principal_name       varchar(200)  NOT NULL,
-    authorities          varchar(1000) NOT NULL,
-    PRIMARY KEY (registered_client_id, principal_name)
-);
+CREATE TABLE IF NOT EXISTS oauth2_authorization_consent
+(
+    registered_client_id
+    varchar
+(
+    100
+) NOT NULL,
+    principal_name varchar
+(
+    200
+) NOT NULL,
+    authorities varchar
+(
+    1000
+) NOT NULL,
+    PRIMARY KEY
+(
+    registered_client_id,
+    principal_name
+)
+    );

--- a/src/main/resources/db/migration/V5__oauth2_registered_client.sql
+++ b/src/main/resources/db/migration/V5__oauth2_registered_client.sql
@@ -61,5 +61,8 @@ CREATE TABLE IF NOT EXISTS oauth2_registered_client
 ALTER TABLE oauth2_registered_client
     ADD COLUMN client_kind VARCHAR(20) NOT NULL DEFAULT 'sso';
 
+CREATE UNIQUE INDEX idx_oauth2_registered_client_client_id
+    ON oauth2_registered_client (client_id);
+
 CREATE INDEX idx_oauth2_registered_client_kind
     ON oauth2_registered_client (client_kind);

--- a/src/main/resources/db/migration/V5__oauth2_registered_client.sql
+++ b/src/main/resources/db/migration/V5__oauth2_registered_client.sql
@@ -1,0 +1,65 @@
+-- Spring Authorization Server registered-client schema (SAS 7.0.5 stock DDL),
+-- with timestamps adjusted to timestamp with time zone to match V2/V3 conventions.
+-- See org/springframework/security/oauth2/server/authorization/client/oauth2-registered-client-schema.sql
+SET
+timezone = 'UTC';
+
+CREATE TABLE IF NOT EXISTS oauth2_registered_client
+(
+    id
+    varchar
+(
+    100
+) NOT NULL,
+    client_id varchar
+(
+    100
+) NOT NULL,
+    client_id_issued_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                                      client_secret varchar (200) DEFAULT NULL,
+    client_secret_expires_at timestamp
+                                  with time zone DEFAULT NULL,
+                                      client_name varchar (200) NOT NULL,
+    client_authentication_methods varchar
+(
+    1000
+) NOT NULL,
+    authorization_grant_types varchar
+(
+    1000
+) NOT NULL,
+    redirect_uris varchar
+(
+    1000
+) DEFAULT NULL,
+    post_logout_redirect_uris varchar
+(
+    1000
+) DEFAULT NULL,
+    scopes varchar
+(
+    1000
+) NOT NULL,
+    client_settings varchar
+(
+    2000
+) NOT NULL,
+    token_settings varchar
+(
+    2000
+) NOT NULL,
+    PRIMARY KEY
+(
+    id
+)
+    );
+
+-- Extension column: classifies a registered client. 'sso' for human SSO clients
+-- (Grafana/HA/n8n/device-service/litellm), 'device' for IoT clients managed
+-- through the admin API. Used by the token customizer to emit device_id only
+-- for IoT clients, and by the admin API to filter listings.
+ALTER TABLE oauth2_registered_client
+    ADD COLUMN client_kind VARCHAR(20) NOT NULL DEFAULT 'sso';
+
+CREATE INDEX idx_oauth2_registered_client_kind
+    ON oauth2_registered_client (client_kind);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -5,14 +5,65 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>furchert.ch — Sign in</title>
     <style>
-        body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
-        .card { background: white; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,.1); width: 100%; max-width: 360px; }
-        h1 { margin-top: 0; font-size: 1.4rem; }
-        input { display: block; width: 100%; padding: .5rem; margin: .5rem 0 1rem; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; font-size: 1rem; }
-        button { width: 100%; padding: .6rem; background: #1a73e8; color: white; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
-        button:hover { background: #1558b0; }
-        .error { color: #c0392b; margin-bottom: 1rem; }
-        .info  { color: #27ae60; margin-bottom: 1rem; }
+        body {
+            font-family: sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: #f5f5f5;
+        }
+
+        .card {
+            background: white;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, .1);
+            width: 100%;
+            max-width: 360px;
+        }
+
+        h1 {
+            margin-top: 0;
+            font-size: 1.4rem;
+        }
+
+        input {
+            display: block;
+            width: 100%;
+            padding: .5rem;
+            margin: .5rem 0 1rem;
+            box-sizing: border-box;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 1rem;
+        }
+
+        button {
+            width: 100%;
+            padding: .6rem;
+            background: #1a73e8;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 1rem;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: #1558b0;
+        }
+
+        .error {
+            color: #c0392b;
+            margin-bottom: 1rem;
+        }
+
+        .info {
+            color: #27ae60;
+            margin-bottom: 1rem;
+        }
     </style>
 </head>
 <body>
@@ -22,7 +73,7 @@
     <p th:if="${param.logout}" class="info">You have been signed out.</p>
     <form method="post" action="/login">
         <label for="username">Username</label>
-        <input id="username" type="text"     name="username" autocomplete="username"     required autofocus/>
+        <input id="username" type="text" name="username" autocomplete="username" required autofocus/>
         <label for="password">Password</label>
         <input id="password" type="password" name="password" autocomplete="current-password" required/>
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>

--- a/src/test/java/ch/furchert/homelab/auth/AbstractIntegrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/AbstractIntegrationTest.java
@@ -4,7 +4,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -14,7 +14,7 @@ public abstract class AbstractIntegrationTest {
     // Do NOT use @Testcontainers + @Container here: JUnit 5's AfterAllCallback
     // stops @Container static fields after each concrete subclass finishes, which
     // kills the container before the next integration test class can connect.
-    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17-alpine");
+    static final PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:17-alpine");
 
     static {
         postgres.start();

--- a/src/test/java/ch/furchert/homelab/auth/AbstractIntegrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/AbstractIntegrationTest.java
@@ -1,7 +1,7 @@
 package ch.furchert.homelab.auth;
 
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -26,6 +26,8 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.username", postgres::getUsername);
         registry.add("spring.datasource.password", postgres::getPassword);
         registry.add("app.oidc.issuer", () -> "https://auth.test.local");
+
+        // clients[0]: replaces grafana — primary test client used by OidcFlowIntegrationTest.
         registry.add("app.oidc.clients[0].client-id", () -> "test-client");
         registry.add("app.oidc.clients[0].client-secret", () -> "{noop}test-secret");
         registry.add("app.oidc.clients[0].redirect-uris[0]", () -> "https://app.test.local/callback");
@@ -33,8 +35,9 @@ public abstract class AbstractIntegrationTest {
         registry.add("app.oidc.clients[0].scopes[0]", () -> "openid");
         registry.add("app.oidc.clients[0].scopes[1]", () -> "profile");
         registry.add("app.oidc.clients[0].scopes[2]", () -> "email");
-        // Override clients[1] so that ${HA_CLIENT_SECRET} and ${GRAFANA_CLIENT_SECRET}
-        // in application.yaml are never evaluated without the env vars present in CI.
+
+        // Override remaining SSO clients so that their ${*_CLIENT_SECRET} placeholders
+        // in application.yaml are never evaluated without env vars present in CI.
         registry.add("app.oidc.clients[1].client-id", () -> "homeassistant");
         registry.add("app.oidc.clients[1].client-secret", () -> "{noop}test-secret-ha");
         registry.add("app.oidc.clients[1].redirect-uris[0]", () -> "https://ha.test.local/callback");
@@ -42,5 +45,35 @@ public abstract class AbstractIntegrationTest {
         registry.add("app.oidc.clients[1].scopes[0]", () -> "openid");
         registry.add("app.oidc.clients[1].scopes[1]", () -> "profile");
         registry.add("app.oidc.clients[1].scopes[2]", () -> "email");
+
+        // clients[2]: device-service — kept multi-grant so S2S tests can exercise
+        // client_credentials with the clients:admin scope.
+        registry.add("app.oidc.clients[2].client-id", () -> "device-service");
+        registry.add("app.oidc.clients[2].client-secret", () -> "{noop}device-service-secret");
+        registry.add("app.oidc.clients[2].redirect-uris[0]", () -> "https://device.test.local/callback");
+        registry.add("app.oidc.clients[2].post-logout-redirect-uris[0]", () -> "https://device.test.local");
+        registry.add("app.oidc.clients[2].scopes[0]", () -> "openid");
+        registry.add("app.oidc.clients[2].scopes[1]", () -> "profile");
+        registry.add("app.oidc.clients[2].scopes[2]", () -> "email");
+        registry.add("app.oidc.clients[2].scopes[3]", () -> "clients:admin");
+        registry.add("app.oidc.clients[2].grant-types[0]", () -> "authorization_code");
+        registry.add("app.oidc.clients[2].grant-types[1]", () -> "refresh_token");
+        registry.add("app.oidc.clients[2].grant-types[2]", () -> "client_credentials");
+
+        registry.add("app.oidc.clients[3].client-id", () -> "n8n");
+        registry.add("app.oidc.clients[3].client-secret", () -> "{noop}test-secret-n8n");
+        registry.add("app.oidc.clients[3].redirect-uris[0]", () -> "https://n8n.test.local/callback");
+        registry.add("app.oidc.clients[3].post-logout-redirect-uris[0]", () -> "https://n8n.test.local");
+        registry.add("app.oidc.clients[3].scopes[0]", () -> "openid");
+        registry.add("app.oidc.clients[3].scopes[1]", () -> "profile");
+        registry.add("app.oidc.clients[3].scopes[2]", () -> "email");
+
+        registry.add("app.oidc.clients[4].client-id", () -> "litellm");
+        registry.add("app.oidc.clients[4].client-secret", () -> "{noop}test-secret-litellm");
+        registry.add("app.oidc.clients[4].redirect-uris[0]", () -> "https://ai.test.local/callback");
+        registry.add("app.oidc.clients[4].post-logout-redirect-uris[0]", () -> "https://ai.test.local");
+        registry.add("app.oidc.clients[4].scopes[0]", () -> "openid");
+        registry.add("app.oidc.clients[4].scopes[1]", () -> "profile");
+        registry.add("app.oidc.clients[4].scopes[2]", () -> "email");
     }
 }

--- a/src/test/java/ch/furchert/homelab/auth/config/OidcClientPropertiesTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/config/OidcClientPropertiesTest.java
@@ -10,19 +10,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = OidcClientPropertiesTest.Config.class)
 @TestPropertySource(properties = {
-    "app.oidc.issuer=https://auth.furchert.ch",
-    "app.oidc.clients[0].client-id=grafana",
-    "app.oidc.clients[0].client-secret={bcrypt}$2a$10$hashedvalue",
-    "app.oidc.clients[0].redirect-uris[0]=https://grafana.furchert.ch/login/generic_oauth",
-    "app.oidc.clients[0].post-logout-redirect-uris[0]=https://grafana.furchert.ch",
-    "app.oidc.clients[0].scopes[0]=openid",
-    "app.oidc.clients[0].scopes[1]=profile",
-    "app.oidc.clients[0].scopes[2]=email"
+        "app.oidc.issuer=https://auth.furchert.ch",
+        "app.oidc.clients[0].client-id=grafana",
+        "app.oidc.clients[0].client-secret={bcrypt}$2a$10$hashedvalue",
+        "app.oidc.clients[0].redirect-uris[0]=https://grafana.furchert.ch/login/generic_oauth",
+        "app.oidc.clients[0].post-logout-redirect-uris[0]=https://grafana.furchert.ch",
+        "app.oidc.clients[0].scopes[0]=openid",
+        "app.oidc.clients[0].scopes[1]=profile",
+        "app.oidc.clients[0].scopes[2]=email"
 })
 class OidcClientPropertiesTest {
 
     @EnableConfigurationProperties(OidcClientProperties.class)
-    static class Config {}
+    static class Config {
+    }
 
     @Autowired
     OidcClientProperties props;
@@ -46,18 +47,18 @@ class OidcClientPropertiesTest {
     @Test
     void loadsRedirectUris() {
         assertThat(props.getClients().get(0).getRedirectUris())
-            .containsExactly("https://grafana.furchert.ch/login/generic_oauth");
+                .containsExactly("https://grafana.furchert.ch/login/generic_oauth");
     }
 
     @Test
     void loadsPostLogoutRedirectUris() {
         assertThat(props.getClients().get(0).getPostLogoutRedirectUris())
-            .containsExactly("https://grafana.furchert.ch");
+                .containsExactly("https://grafana.furchert.ch");
     }
 
     @Test
     void loadsScopes() {
         assertThat(props.getClients().get(0).getScopes())
-            .containsExactlyInAnyOrder("openid", "profile", "email");
+                .containsExactlyInAnyOrder("openid", "profile", "email");
     }
 }

--- a/src/test/java/ch/furchert/homelab/auth/config/SecurityConfigConverterTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/config/SecurityConfigConverterTest.java
@@ -1,0 +1,100 @@
+package ch.furchert.homelab.auth.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityConfigConverterTest {
+
+    private final JwtAuthenticationConverter converter = SecurityConfig.jwtAuthenticationConverter();
+
+    /**
+     * Spring Security 7 injects a FactorGrantedAuthority(FACTOR_BEARER) into every
+     * resource-server JWT authentication; the converter-emitted authorities live
+     * alongside it. The tests focus on what the project's converter contributes.
+     */
+    private static List<String> projectAuthorities(AbstractAuthenticationToken auth) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(a -> a.startsWith("ROLE_") || a.startsWith("SCOPE_"))
+                .toList();
+    }
+
+    @Test
+    void emitsRoleAndScopeAuthorities() {
+        Jwt jwt = Jwt.withTokenValue("t")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .claim("role", "ADMIN")
+                .claim("scope", "openid profile email")
+                .build();
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+
+        assertThat(projectAuthorities(auth))
+                .contains("ROLE_ADMIN", "SCOPE_openid", "SCOPE_profile", "SCOPE_email");
+    }
+
+    @Test
+    void ssoJwtDoesNotGrantClientsAdmin() {
+        Jwt jwt = Jwt.withTokenValue("t")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .claim("role", "USER")
+                .claim("scope", "openid profile email")
+                .build();
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+
+        assertThat(projectAuthorities(auth))
+                .doesNotContain("SCOPE_clients:admin");
+    }
+
+    @Test
+    void clientCredentialsJwtWithClientsAdminScope() {
+        Jwt jwt = Jwt.withTokenValue("t")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .claim("scope", "clients:admin")
+                .build();
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+
+        assertThat(projectAuthorities(auth))
+                .contains("SCOPE_clients:admin");
+    }
+
+    @Test
+    void jwtMissingBothClaimsDoesNotThrow() {
+        Jwt jwt = Jwt.withTokenValue("t")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .claim("sub", "anonymous")
+                .build();
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+
+        assertThat(projectAuthorities(auth)).isEmpty();
+    }
+
+    @Test
+    void jwtWithRoleButNoScope() {
+        Jwt jwt = Jwt.withTokenValue("t")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now()).expiresAt(Instant.now().plusSeconds(60))
+                .claim("role", "ADMIN")
+                .build();
+
+        AbstractAuthenticationToken auth = converter.convert(jwt);
+
+        assertThat(projectAuthorities(auth))
+                .containsExactly("ROLE_ADMIN");
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/config/StaticClientSeederTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/config/StaticClientSeederTest.java
@@ -1,0 +1,136 @@
+package ch.furchert.homelab.auth.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StaticClientSeederTest {
+
+    @Mock
+    RegisteredClientRepository repo;
+    @Mock
+    JdbcTemplate jdbcTemplate;
+
+    private OidcClientProperties props;
+    private RsaKeyProperties rsaKeyProperties;
+    private StaticClientSeeder seeder;
+
+    @BeforeEach
+    void setUp() {
+        props = new OidcClientProperties();
+        props.setIssuer("https://auth.test");
+        rsaKeyProperties = new RsaKeyProperties();
+        rsaKeyProperties.setAccessTokenExpiry(900_000L);
+        rsaKeyProperties.setRefreshTokenExpiry(604_800_000L);
+        seeder = new StaticClientSeeder(props, rsaKeyProperties, repo, jdbcTemplate);
+    }
+
+    private static RegisteredClient stubClient(String clientId) {
+        // Minimal valid RegisteredClient for return values from findByClientId mocks.
+        // Uses client_credentials grant to avoid auth_code's redirectUris validation.
+        return RegisteredClient.withId("stub-" + clientId).clientId(clientId)
+                .clientSecret("{noop}stub")
+                .clientAuthenticationMethod(
+                        org.springframework.security.oauth2.core.ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(
+                        org.springframework.security.oauth2.core.AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .build();
+    }
+
+    private OidcClientProperties.ClientDefinition def(String id, String secret) {
+        OidcClientProperties.ClientDefinition d = new OidcClientProperties.ClientDefinition();
+        d.setClientId(id);
+        d.setClientSecret(secret);
+        d.setRedirectUris(new ArrayList<>(List.of("https://" + id + ".test/callback")));
+        d.setPostLogoutRedirectUris(new ArrayList<>(List.of("https://" + id + ".test")));
+        d.setScopes(new ArrayList<>(List.of("openid", "profile", "email")));
+        return d;
+    }
+
+    @Test
+    void seedsEmptyDb() {
+        props.getClients().add(def("grafana", "{noop}gs"));
+        props.getClients().add(def("ha", "{noop}hs"));
+        when(repo.findByClientId(any())).thenReturn(null);
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class))).thenReturn(2);
+
+        seeder.run(null);
+
+        verify(repo, times(2)).save(any());
+        // No explicit UPDATE for client_kind — relies on the DEFAULT 'sso' column value.
+        verify(jdbcTemplate, never()).update(any(String.class), eq("sso"), any());
+    }
+
+    @Test
+    void skipsExistingClient() {
+        props.getClients().add(def("grafana", "{noop}gs"));
+        when(repo.findByClientId("grafana")).thenReturn(stubClient("grafana"));
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class))).thenReturn(1);
+
+        seeder.run(null);
+
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void mixedExistingAndNew() {
+        props.getClients().add(def("grafana", "{noop}gs"));
+        props.getClients().add(def("ha", "{noop}hs"));
+        props.getClients().add(def("n8n", "{noop}ns"));
+        when(repo.findByClientId("grafana")).thenReturn(stubClient("grafana"));
+        when(repo.findByClientId("ha")).thenReturn(null);
+        when(repo.findByClientId("n8n")).thenReturn(null);
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class))).thenReturn(3);
+
+        seeder.run(null);
+
+        verify(repo, times(2)).save(any());
+    }
+
+    @Test
+    void persistedSecretEqualsYamlVerbatim() {
+        // Critical: the seeder must NOT re-encode the YAML secret (F1 — double-hash bug).
+        props.getClients().add(def("grafana", "{bcrypt}$2a$10$alreadyHashedValue"));
+        when(repo.findByClientId(any())).thenReturn(null);
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class))).thenReturn(1);
+
+        seeder.run(null);
+
+        ArgumentCaptor<RegisteredClient> captor = ArgumentCaptor.forClass(RegisteredClient.class);
+        verify(repo).save(captor.capture());
+        assertThat(captor.getValue().getClientSecret())
+                .isEqualTo("{bcrypt}$2a$10$alreadyHashedValue");
+    }
+
+    @Test
+    void appliesYamlGrantTypes() {
+        OidcClientProperties.ClientDefinition d = def("device-service", "{noop}s");
+        d.setGrantTypes(new ArrayList<>(List.of("authorization_code", "refresh_token", "client_credentials")));
+        props.getClients().add(d);
+        when(repo.findByClientId(any())).thenReturn(null);
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class))).thenReturn(1);
+
+        seeder.run(null);
+
+        ArgumentCaptor<RegisteredClient> captor = ArgumentCaptor.forClass(RegisteredClient.class);
+        verify(repo).save(captor.capture());
+        assertThat(captor.getValue().getAuthorizationGrantTypes())
+                .extracting(org.springframework.security.oauth2.core.AuthorizationGrantType::getValue)
+                .containsExactlyInAnyOrder("authorization_code", "refresh_token", "client_credentials");
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/controller/DeviceClientControllerTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/controller/DeviceClientControllerTest.java
@@ -1,0 +1,177 @@
+package ch.furchert.homelab.auth.controller;
+
+import ch.furchert.homelab.auth.config.SecurityConfig;
+import ch.furchert.homelab.auth.dto.CreateDeviceClientRequest;
+import ch.furchert.homelab.auth.dto.DeviceClientCreatedResponse;
+import ch.furchert.homelab.auth.dto.DeviceClientResponse;
+import ch.furchert.homelab.auth.exception.ResourceConflictException;
+import ch.furchert.homelab.auth.exception.ResourceNotFoundException;
+import ch.furchert.homelab.auth.service.DeviceClientService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DeviceClientController.class)
+@Import(SecurityConfig.class)
+class DeviceClientControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @MockitoBean
+    JwtDecoder jwtDecoder;
+    @MockitoBean
+    DeviceClientService deviceClientService;
+
+    @Test
+    void create_asAdmin_returns201WithPlaintextSecret() throws Exception {
+        DeviceClientCreatedResponse created = new DeviceClientCreatedResponse(
+                "terra1", "plain-secret-123", List.of("mqtt:pub", "mqtt:sub"), Instant.now());
+        when(deviceClientService.create("terra1", "Greenhouse 1")).thenReturn(created);
+
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateDeviceClientRequest("terra1", "Greenhouse 1"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.clientId").value("terra1"))
+                .andExpect(jsonPath("$.clientSecret").value("plain-secret-123"));
+    }
+
+    @Test
+    void create_withScopeClientsAdmin_returns201() throws Exception {
+        DeviceClientCreatedResponse created = new DeviceClientCreatedResponse(
+                "terra2", "secret", List.of("mqtt:pub", "mqtt:sub"), Instant.now());
+        when(deviceClientService.create(eq("terra2"), any())).thenReturn(created);
+
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("SCOPE_clients:admin")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateDeviceClientRequest("terra2", null))))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void create_asPlainUser_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateDeviceClientRequest("terra1", null))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(deviceClientService);
+    }
+
+    @Test
+    void create_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateDeviceClientRequest("terra1", null))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void create_withInvalidClientIdPattern_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"clientId\":\"UPPER\",\"description\":null}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_withTooShortClientId_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"clientId\":\"x\",\"description\":null}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_duplicateClientId_returns409() throws Exception {
+        when(deviceClientService.create(eq("terra1"), any()))
+                .thenThrow(new ResourceConflictException("exists"));
+
+        mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CreateDeviceClientRequest("terra1", null))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void list_asAdmin_returns200() throws Exception {
+        when(deviceClientService.list()).thenReturn(List.of(
+                new DeviceClientResponse("terra1", "Greenhouse 1", Instant.now(),
+                        List.of("mqtt:pub", "mqtt:sub"))));
+
+        mockMvc.perform(get("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].clientId").value("terra1"));
+    }
+
+    @Test
+    void get_unknown_returns404() throws Exception {
+        when(deviceClientService.get("ghost"))
+                .thenThrow(new ResourceNotFoundException("not found"));
+
+        mockMvc.perform(get("/api/v1/clients/ghost")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void delete_returns204AndCallsService() throws Exception {
+        doNothing().when(deviceClientService).delete("terra1");
+
+        mockMvc.perform(delete("/api/v1/clients/terra1")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        verify(deviceClientService).delete("terra1");
+    }
+
+    @Test
+    void delete_missing_returns204Idempotent() throws Exception {
+        doNothing().when(deviceClientService).delete("ghost");
+
+        mockMvc.perform(delete("/api/v1/clients/ghost")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void delete_asPlainUser_returns403() throws Exception {
+        mockMvc.perform(delete("/api/v1/clients/terra1")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                .andExpect(status().isForbidden());
+
+        verifyNoInteractions(deviceClientService);
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/controller/UserControllerTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/controller/UserControllerTest.java
@@ -7,7 +7,6 @@ import ch.furchert.homelab.auth.dto.UserResponse;
 import ch.furchert.homelab.auth.entity.Role;
 import ch.furchert.homelab.auth.exception.ResourceNotFoundException;
 import ch.furchert.homelab.auth.service.UserService;
-import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -17,15 +16,18 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
 @Import(SecurityConfig.class)
@@ -95,7 +97,7 @@ class UserControllerTest {
 
         mockMvc.perform(get("/api/v1/users/1")
                         .with(jwt().jwt(j -> j.subject("testuser"))
-                                   .authorities(new SimpleGrantedAuthority("ROLE_USER"))))
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("testuser"));
     }

--- a/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
@@ -17,7 +17,9 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -105,8 +107,9 @@ class DeviceClientLifecycleIT extends AbstractIntegrationTest {
         // The JWT scope claim is encoded as an array by Spring Authorization Server.
         JsonNode scopeNode = payload.get("scope");
         assertThat(scopeNode.isArray()).as("scope claim is an array").isTrue();
-        assertThat(scopeNode).extracting(JsonNode::asString)
-                .containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
+        List<String> scopeList = new ArrayList<>();
+        scopeNode.forEach(n -> scopeList.add(n.asString()));
+        assertThat(scopeList).containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
 
         // Step 3: DELETE the client — must remove the registered_client row and
         // any oauth2_authorization rows that reference it.

--- a/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
@@ -1,0 +1,159 @@
+package ch.furchert.homelab.auth.integration;
+
+import ch.furchert.homelab.auth.AbstractIntegrationTest;
+import ch.furchert.homelab.auth.entity.Role;
+import ch.furchert.homelab.auth.entity.User;
+import ch.furchert.homelab.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end lifecycle of an IoT device client: create via admin API → mint a
+ * client_credentials JWT → delete → assert token endpoint refuses new requests.
+ * <p>
+ * Note (per SPEC and plan §C4 / F5): JWTs issued before delete remain valid at
+ * any resource server that only checks signature + exp until they expire. The
+ * delete only revokes the AS authorization rows and refuses new token requests.
+ */
+class DeviceClientLifecycleIT extends AbstractIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void seedAdminUser() {
+        if (userRepository.findByUsername("itadmin").isEmpty()) {
+            User u = new User();
+            u.setUsername("itadmin");
+            u.setEmail("itadmin@test.local");
+            u.setPasswordHash(passwordEncoder.encode("ignored"));
+            u.setRole(Role.ADMIN);
+            u.setStatus("ACTIVE");
+            userRepository.save(u);
+        }
+    }
+
+    @Test
+    void fullLifecycle_createTokenDelete() throws Exception {
+        // Step 1: ADMIN creates a device client.
+        MvcResult createResult = mockMvc.perform(post("/api/v1/clients")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                                .jwt(j -> j.subject("itadmin")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"clientId\":\"terra-lc\",\"description\":\"lifecycle test\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.clientId").value("terra-lc"))
+                .andExpect(jsonPath("$.clientSecret").isString())
+                .andReturn();
+
+        JsonNode createBody = objectMapper.readTree(
+                createResult.getResponse().getContentAsString());
+        String plaintextSecret = createBody.get("clientSecret").asText();
+        assertThat(plaintextSecret).isNotBlank();
+
+        // Step 2: Mint a client_credentials access token using basic auth.
+        String basic = Base64.getEncoder().encodeToString(
+                ("terra-lc:" + plaintextSecret).getBytes(StandardCharsets.UTF_8));
+
+        MvcResult tokenResult = mockMvc.perform(post("/oauth2/token")
+                        .header("Authorization", "Basic " + basic)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content("grant_type=client_credentials&scope=mqtt:pub+mqtt:sub"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").isString())
+                .andExpect(jsonPath("$.token_type").value("Bearer"))
+                .andReturn();
+
+        JsonNode tokenBody = objectMapper.readTree(
+                tokenResult.getResponse().getContentAsString());
+        String accessToken = tokenBody.get("access_token").asText();
+        assertThat(accessToken.split("\\.")).hasSize(3);
+
+        // Decode payload — assert device_id and scope claims.
+        String payloadJson = new String(
+                Base64.getUrlDecoder().decode(accessToken.split("\\.")[1]),
+                StandardCharsets.UTF_8);
+        JsonNode payload = objectMapper.readTree(payloadJson);
+        assertThat(payload.get("device_id").asText()).isEqualTo("terra-lc");
+        // The JWT scope claim is encoded as an array by Spring Authorization Server.
+        JsonNode scopeNode = payload.get("scope");
+        assertThat(scopeNode.isArray()).as("scope claim is an array").isTrue();
+        assertThat(scopeNode).extracting(JsonNode::asText)
+                .containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
+
+        // Step 3: DELETE the client — must remove the registered_client row and
+        // any oauth2_authorization rows that reference it.
+        Integer authRowsBefore = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_authorization a "
+                        + "JOIN oauth2_registered_client c ON c.id = a.registered_client_id "
+                        + "WHERE c.client_id = ?", Integer.class, "terra-lc");
+        assertThat(authRowsBefore).isGreaterThanOrEqualTo(1);
+
+        mockMvc.perform(delete("/api/v1/clients/terra-lc")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                                .jwt(j -> j.subject("itadmin"))))
+                .andExpect(status().isNoContent());
+
+        Integer clientRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = ?",
+                Integer.class, "terra-lc");
+        assertThat(clientRows).isZero();
+
+        // Step 4: A new token request with the same credentials must fail.
+        mockMvc.perform(post("/oauth2/token")
+                        .header("Authorization", "Basic " + basic)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content("grant_type=client_credentials&scope=mqtt:pub+mqtt:sub"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deleteSsoClientId_isIdempotentAndDoesNotTouchSsoRows() throws Exception {
+        // Before: count SSO rows for grafana (seeded by StaticClientSeeder).
+        // test-client is the seeded SSO client (replacing clients[0]) used by
+        // OidcFlowIntegrationTest. It must NOT be deletable via /api/v1/clients/{id}.
+        Integer rowsBefore = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = ?",
+                Integer.class, "test-client");
+        assertThat(rowsBefore).isEqualTo(1);
+
+        mockMvc.perform(delete("/api/v1/clients/test-client")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))
+                                .jwt(j -> j.subject("itadmin"))))
+                .andExpect(status().isNoContent());
+
+        Integer rowsAfter = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = ?",
+                Integer.class, "test-client");
+        assertThat(rowsAfter)
+                .as("SSO client must NOT be deleted via the device admin API")
+                .isEqualTo(1);
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/DeviceClientLifecycleIT.java
@@ -75,7 +75,7 @@ class DeviceClientLifecycleIT extends AbstractIntegrationTest {
 
         JsonNode createBody = objectMapper.readTree(
                 createResult.getResponse().getContentAsString());
-        String plaintextSecret = createBody.get("clientSecret").asText();
+        String plaintextSecret = createBody.get("clientSecret").asString();
         assertThat(plaintextSecret).isNotBlank();
 
         // Step 2: Mint a client_credentials access token using basic auth.
@@ -93,7 +93,7 @@ class DeviceClientLifecycleIT extends AbstractIntegrationTest {
 
         JsonNode tokenBody = objectMapper.readTree(
                 tokenResult.getResponse().getContentAsString());
-        String accessToken = tokenBody.get("access_token").asText();
+        String accessToken = tokenBody.get("access_token").asString();
         assertThat(accessToken.split("\\.")).hasSize(3);
 
         // Decode payload — assert device_id and scope claims.
@@ -101,11 +101,11 @@ class DeviceClientLifecycleIT extends AbstractIntegrationTest {
                 Base64.getUrlDecoder().decode(accessToken.split("\\.")[1]),
                 StandardCharsets.UTF_8);
         JsonNode payload = objectMapper.readTree(payloadJson);
-        assertThat(payload.get("device_id").asText()).isEqualTo("terra-lc");
+        assertThat(payload.get("device_id").asString()).isEqualTo("terra-lc");
         // The JWT scope claim is encoded as an array by Spring Authorization Server.
         JsonNode scopeNode = payload.get("scope");
         assertThat(scopeNode.isArray()).as("scope claim is an array").isTrue();
-        assertThat(scopeNode).extracting(JsonNode::asText)
+        assertThat(scopeNode).extracting(JsonNode::asString)
                 .containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
 
         // Step 3: DELETE the client — must remove the registered_client row and

--- a/src/test/java/ch/furchert/homelab/auth/integration/FlywayMigrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/FlywayMigrationTest.java
@@ -15,16 +15,40 @@ class FlywayMigrationTest extends AbstractIntegrationTest {
     @Test
     void oauth2AuthorizationTableExists() {
         Integer count = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM information_schema.tables " +
-            "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization'", Integer.class);
+                "SELECT COUNT(*) FROM information_schema.tables " +
+                        "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization'", Integer.class);
         assertThat(count).isEqualTo(1);
     }
 
     @Test
     void oauth2AuthorizationConsentTableExists() {
         Integer count = jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM information_schema.tables " +
-            "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization_consent'", Integer.class);
+                "SELECT COUNT(*) FROM information_schema.tables " +
+                        "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization_consent'", Integer.class);
         assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void oauth2RegisteredClientTableExists() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.tables " +
+                        "WHERE table_schema = 'public' AND table_name = 'oauth2_registered_client'", Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void oauth2RegisteredClientHasClientKindColumnWithSsoDefault() {
+        // The V5 migration adds client_kind VARCHAR(20) NOT NULL DEFAULT 'sso'.
+        Integer columnCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.columns " +
+                        "WHERE table_schema = 'public' AND table_name = 'oauth2_registered_client' " +
+                        "AND column_name = 'client_kind'", Integer.class);
+        assertThat(columnCount).isEqualTo(1);
+
+        String columnDefault = jdbcTemplate.queryForObject(
+                "SELECT column_default FROM information_schema.columns " +
+                        "WHERE table_schema = 'public' AND table_name = 'oauth2_registered_client' " +
+                        "AND column_name = 'client_kind'", String.class);
+        assertThat(columnDefault).contains("sso");
     }
 }

--- a/src/test/java/ch/furchert/homelab/auth/integration/FlywayMigrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/FlywayMigrationTest.java
@@ -2,6 +2,8 @@ package ch.furchert.homelab.auth.integration;
 
 import ch.furchert.homelab.auth.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -12,27 +14,12 @@ class FlywayMigrationTest extends AbstractIntegrationTest {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    @Test
-    void oauth2AuthorizationTableExists() {
+    @ParameterizedTest
+    @ValueSource(strings = {"oauth2_authorization", "oauth2_authorization_consent", "oauth2_registered_client"})
+    void tableExists(String tableName) {
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM information_schema.tables " +
-                        "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization'", Integer.class);
-        assertThat(count).isEqualTo(1);
-    }
-
-    @Test
-    void oauth2AuthorizationConsentTableExists() {
-        Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM information_schema.tables " +
-                        "WHERE table_schema = 'public' AND table_name = 'oauth2_authorization_consent'", Integer.class);
-        assertThat(count).isEqualTo(1);
-    }
-
-    @Test
-    void oauth2RegisteredClientTableExists() {
-        Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM information_schema.tables " +
-                        "WHERE table_schema = 'public' AND table_name = 'oauth2_registered_client'", Integer.class);
+                        "WHERE table_schema = 'public' AND table_name = ?", Integer.class, tableName);
         assertThat(count).isEqualTo(1);
     }
 

--- a/src/test/java/ch/furchert/homelab/auth/integration/OidcFlowIntegrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/OidcFlowIntegrationTest.java
@@ -28,10 +28,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class OidcFlowIntegrationTest extends AbstractIntegrationTest {
 
-    @Autowired MockMvc mockMvc;
-    @Autowired UserRepository userRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-    @Autowired ObjectMapper objectMapper;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+    @Autowired
+    ObjectMapper objectMapper;
 
     @BeforeEach
     void createTestUser() {
@@ -49,12 +53,12 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
     @Test
     void oidcDiscoveryEndpointIsReachable() throws Exception {
         mockMvc.perform(get("/.well-known/openid-configuration"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.issuer").value("https://auth.test.local"))
-            .andExpect(jsonPath("$.authorization_endpoint").exists())
-            .andExpect(jsonPath("$.token_endpoint").exists())
-            .andExpect(jsonPath("$.jwks_uri").exists())
-            .andExpect(jsonPath("$.userinfo_endpoint").exists());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.issuer").value("https://auth.test.local"))
+                .andExpect(jsonPath("$.authorization_endpoint").exists())
+                .andExpect(jsonPath("$.token_endpoint").exists())
+                .andExpect(jsonPath("$.jwks_uri").exists())
+                .andExpect(jsonPath("$.userinfo_endpoint").exists());
     }
 
     @Test
@@ -62,16 +66,16 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
         var client = clientRepo.findByClientId("test-client");
         assertThat(client).isNotNull();
         assertThat(client.getScopes())
-            .as("Registered client 'test-client' scopes")
-            .containsExactlyInAnyOrder("openid", "profile", "email");
+                .as("Registered client 'test-client' scopes")
+                .containsExactlyInAnyOrder("openid", "profile", "email");
     }
 
     @Test
     void jwksEndpointReturnsPublicKey() throws Exception {
         mockMvc.perform(get("/oauth2/jwks"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.keys[0].kid").value("auth-service-v1"))
-            .andExpect(jsonPath("$.keys[0].kty").value("RSA"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.keys[0].kid").value("auth-service-v1"))
+                .andExpect(jsonPath("$.keys[0].kty").value("RSA"));
     }
 
     @Test
@@ -85,23 +89,23 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
         // We use .param() for decoded values + a RequestPostProcessor to set the
         // raw query string so Spring AS can find the parameter keys.
         mockMvc.perform(get("/oauth2/authorize")
-                .param("response_type", "code")
-                .param("client_id", "test-client")
-                .param("redirect_uri", "https://app.test.local/callback")
-                .param("scope", "openid profile email")
-                .param("state", "test-state")
-                .param("code_challenge", codeChallenge)
-                .param("code_challenge_method", "S256")
-                .with(request -> {
-                    request.setQueryString(buildQueryString(codeChallenge));
-                    return request;
-                }))
-            .andExpect(status().is3xxRedirection())
-            .andExpect(result -> {
-                String redirectUrl = result.getResponse().getRedirectedUrl();
-                assertThat(redirectUrl).isNotNull();
-                assertThat(redirectUrl).contains("/login");
-            });
+                        .param("response_type", "code")
+                        .param("client_id", "test-client")
+                        .param("redirect_uri", "https://app.test.local/callback")
+                        .param("scope", "openid profile email")
+                        .param("state", "test-state")
+                        .param("code_challenge", codeChallenge)
+                        .param("code_challenge_method", "S256")
+                        .with(request -> {
+                            request.setQueryString(buildQueryString(codeChallenge));
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result -> {
+                    String redirectUrl = result.getResponse().getRedirectedUrl();
+                    assertThat(redirectUrl).isNotNull();
+                    assertThat(redirectUrl).contains("/login");
+                });
     }
 
     @Test
@@ -111,30 +115,30 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
 
         // Step 1: GET /oauth2/authorize → 302 to /login
         MvcResult authorizeResult = mockMvc.perform(get("/oauth2/authorize")
-                .param("response_type", "code")
-                .param("client_id", "test-client")
-                .param("redirect_uri", "https://app.test.local/callback")
-                .param("scope", "openid profile email")
-                .param("state", "test-state")
-                .param("code_challenge", codeChallenge)
-                .param("code_challenge_method", "S256")
-                .with(request -> {
-                    request.setQueryString(buildQueryString(codeChallenge));
-                    return request;
-                }))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
+                        .param("response_type", "code")
+                        .param("client_id", "test-client")
+                        .param("redirect_uri", "https://app.test.local/callback")
+                        .param("scope", "openid profile email")
+                        .param("state", "test-state")
+                        .param("code_challenge", codeChallenge)
+                        .param("code_challenge_method", "S256")
+                        .with(request -> {
+                            request.setQueryString(buildQueryString(codeChallenge));
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
 
         MockHttpSession session = (MockHttpSession) authorizeResult.getRequest().getSession();
 
         // Step 2: POST /login with credentials
         MvcResult loginResult = mockMvc.perform(post("/login")
-                .param("username", "testuser")
-                .param("password", "password123")
-                .session(session)
-                .with(csrf()))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
+                        .param("username", "testuser")
+                        .param("password", "password123")
+                        .session(session)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
 
         session = (MockHttpSession) loginResult.getRequest().getSession();
         String loginRedirect = loginResult.getResponse().getRedirectedUrl();
@@ -144,20 +148,20 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
         // We cannot simply GET the loginRedirect URL because MockMvc re-encodes
         // query params (%20 / +), causing Spring AS scope validation to fail.
         MvcResult codeResult = mockMvc.perform(get("/oauth2/authorize")
-                .param("response_type", "code")
-                .param("client_id", "test-client")
-                .param("redirect_uri", "https://app.test.local/callback")
-                .param("scope", "openid profile email")
-                .param("state", "test-state")
-                .param("code_challenge", codeChallenge)
-                .param("code_challenge_method", "S256")
-                .session(session)
-                .with(request -> {
-                    request.setQueryString(buildQueryString(codeChallenge));
-                    return request;
-                }))
-            .andExpect(status().is3xxRedirection())
-            .andReturn();
+                        .param("response_type", "code")
+                        .param("client_id", "test-client")
+                        .param("redirect_uri", "https://app.test.local/callback")
+                        .param("scope", "openid profile email")
+                        .param("state", "test-state")
+                        .param("code_challenge", codeChallenge)
+                        .param("code_challenge_method", "S256")
+                        .session(session)
+                        .with(request -> {
+                            request.setQueryString(buildQueryString(codeChallenge));
+                            return request;
+                        }))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
 
         String callbackUrl = codeResult.getResponse().getRedirectedUrl();
         assertThat(callbackUrl).isNotNull().contains("code=").contains("state=test-state");
@@ -166,17 +170,17 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
 
         // Step 4: POST /oauth2/token — exchange code for tokens
         MvcResult tokenResult = mockMvc.perform(post("/oauth2/token")
-                .param("grant_type", "authorization_code")
-                .param("code", code)
-                .param("redirect_uri", "https://app.test.local/callback")
-                .param("code_verifier", codeVerifier)
-                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
-                    "test-client:test-secret".getBytes(StandardCharsets.UTF_8))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.access_token").exists())
-            .andExpect(jsonPath("$.id_token").exists())
-            .andExpect(jsonPath("$.token_type").value("Bearer"))
-            .andReturn();
+                        .param("grant_type", "authorization_code")
+                        .param("code", code)
+                        .param("redirect_uri", "https://app.test.local/callback")
+                        .param("code_verifier", codeVerifier)
+                        .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+                                "test-client:test-secret".getBytes(StandardCharsets.UTF_8))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.id_token").exists())
+                .andExpect(jsonPath("$.token_type").value("Bearer"))
+                .andReturn();
 
         JsonNode tokenResponse = objectMapper.readTree(
                 tokenResult.getResponse().getContentAsString());
@@ -186,49 +190,77 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
 
         // Verify role claim in id_token payload
         String idTokenPayload = new String(
-            Base64.getUrlDecoder().decode(idToken.split("\\.")[1]), StandardCharsets.UTF_8);
+                Base64.getUrlDecoder().decode(idToken.split("\\.")[1]), StandardCharsets.UTF_8);
         assertThat(idTokenPayload).contains("\"role\"");
 
         // Step 5: GET /userinfo with access token
         mockMvc.perform(get("/userinfo")
-                .header("Authorization", "Bearer " + accessToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.sub").value("testuser"))
-            .andExpect(jsonPath("$.email").value("testuser@test.local"))
-            .andExpect(jsonPath("$.preferred_username").value("testuser"));
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sub").value("testuser"))
+                .andExpect(jsonPath("$.email").value("testuser@test.local"))
+                .andExpect(jsonPath("$.preferred_username").value("testuser"));
+    }
+
+    @Test
+    void deviceServiceCanMintClientCredentialsToken() throws Exception {
+        // F7 — verifies device-service's added client_credentials grant works
+        // without breaking the existing authorization_code path (covered above).
+        // Per memory feedback_mockmvc_querystring, the AS token endpoint reads
+        // form parameters from the request body via content() (POST is fine).
+        String basic = Base64.getEncoder().encodeToString(
+                "device-service:device-service-secret".getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mockMvc.perform(post("/oauth2/token")
+                        .header("Authorization", "Basic " + basic)
+                        .contentType(org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED)
+                        .content("grant_type=client_credentials&scope=clients:admin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.token_type").value("Bearer"))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        String accessToken = body.get("access_token").asText();
+        String payload = new String(
+                Base64.getUrlDecoder().decode(accessToken.split("\\.")[1]),
+                StandardCharsets.UTF_8);
+        // device-service is client_kind='sso', so NO device_id claim must be emitted.
+        assertThat(payload).doesNotContain("device_id");
+        assertThat(payload).contains("clients:admin");
     }
 
     @Test
     void tokenEndpointRejectsInvalidCode() throws Exception {
         mockMvc.perform(post("/oauth2/token")
-                .param("grant_type", "authorization_code")
-                .param("code", "invalid-code")
-                .param("redirect_uri", "https://app.test.local/callback")
-                .param("code_verifier", "some-verifier")
-                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
-                    "test-client:test-secret".getBytes(StandardCharsets.UTF_8))))
-            .andExpect(status().isBadRequest());
+                        .param("grant_type", "authorization_code")
+                        .param("code", "invalid-code")
+                        .param("redirect_uri", "https://app.test.local/callback")
+                        .param("code_verifier", "some-verifier")
+                        .header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+                                "test-client:test-secret".getBytes(StandardCharsets.UTF_8))))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     void adminApiRequiresBearerToken() throws Exception {
         mockMvc.perform(get("/api/v1/users"))
-            .andExpect(status().isUnauthorized());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
     void loginPageIsRendered() throws Exception {
         mockMvc.perform(get("/login"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentTypeCompatibleWith("text/html"));
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/html"));
     }
 
     @Test
     void oidcDiscoveryAdvertisesLogoutEndpoint() throws Exception {
         mockMvc.perform(get("/.well-known/openid-configuration"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.end_session_endpoint").value(
-                org.hamcrest.Matchers.endsWith("/connect/logout")));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.end_session_endpoint").value(
+                        org.hamcrest.Matchers.endsWith("/connect/logout")));
     }
 
     // --- helpers ---

--- a/src/test/java/ch/furchert/homelab/auth/integration/OidcFlowIntegrationTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/integration/OidcFlowIntegrationTest.java
@@ -132,6 +132,7 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
         MockHttpSession session = (MockHttpSession) authorizeResult.getRequest().getSession();
 
         // Step 2: POST /login with credentials
+        assert session != null;
         MvcResult loginResult = mockMvc.perform(post("/login")
                         .param("username", "testuser")
                         .param("password", "password123")
@@ -147,6 +148,7 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
         // Step 3: Replay authorize request with authenticated session.
         // We cannot simply GET the loginRedirect URL because MockMvc re-encodes
         // query params (%20 / +), causing Spring AS scope validation to fail.
+        assert session != null;
         MvcResult codeResult = mockMvc.perform(get("/oauth2/authorize")
                         .param("response_type", "code")
                         .param("client_id", "test-client")
@@ -184,8 +186,8 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
 
         JsonNode tokenResponse = objectMapper.readTree(
                 tokenResult.getResponse().getContentAsString());
-        String accessToken = tokenResponse.get("access_token").asText();
-        String idToken = tokenResponse.get("id_token").asText();
+        String accessToken = tokenResponse.get("access_token").asString();
+        String idToken = tokenResponse.get("id_token").asString();
         assertThat(accessToken).isNotEmpty();
 
         // Verify role claim in id_token payload
@@ -221,13 +223,14 @@ class OidcFlowIntegrationTest extends AbstractIntegrationTest {
                 .andReturn();
 
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        String accessToken = body.get("access_token").asText();
+        String accessToken = body.get("access_token").asString();
         String payload = new String(
                 Base64.getUrlDecoder().decode(accessToken.split("\\.")[1]),
                 StandardCharsets.UTF_8);
         // device-service is client_kind='sso', so NO device_id claim must be emitted.
-        assertThat(payload).doesNotContain("device_id");
-        assertThat(payload).contains("clients:admin");
+        assertThat(payload)
+                .doesNotContain("device_id")
+                .contains("clients:admin");
     }
 
     @Test

--- a/src/test/java/ch/furchert/homelab/auth/security/OidcUserInfoMapperTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/security/OidcUserInfoMapperTest.java
@@ -13,7 +13,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OidcUserInfoMapperTest {
 
@@ -89,7 +90,7 @@ class OidcUserInfoMapperTest {
         when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> mapper.apply(contextFor("ghost")))
-            .isInstanceOf(org.springframework.security.core.userdetails.UsernameNotFoundException.class);
+                .isInstanceOf(org.springframework.security.core.userdetails.UsernameNotFoundException.class);
     }
 
     private User userWith(String username, String email, Role role) {

--- a/src/test/java/ch/furchert/homelab/auth/security/OidcUserInfoMapperTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/security/OidcUserInfoMapperTest.java
@@ -62,7 +62,7 @@ class OidcUserInfoMapperTest {
 
         OidcUserInfo info = mapper.apply(contextFor("dominic"));
 
-        assertThat(info.getClaims().get("preferred_username")).isEqualTo("dominic");
+        assertThat(info.getClaims()).containsEntry("preferred_username", "dominic");
     }
 
     @Test
@@ -72,7 +72,7 @@ class OidcUserInfoMapperTest {
 
         OidcUserInfo info = mapper.apply(contextFor("dominic"));
 
-        assertThat(info.getClaims().get("role")).isEqualTo("USER");
+        assertThat(info.getClaims()).containsEntry("role", "USER");
     }
 
     @Test
@@ -82,7 +82,7 @@ class OidcUserInfoMapperTest {
 
         OidcUserInfo info = mapper.apply(contextFor("admin"));
 
-        assertThat(info.getClaims().get("role")).isEqualTo("ADMIN");
+        assertThat(info.getClaims()).containsEntry("role", "ADMIN");
     }
 
     @Test

--- a/src/test/java/ch/furchert/homelab/auth/service/ClientKindLookupTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/service/ClientKindLookupTest.java
@@ -1,0 +1,73 @@
+package ch.furchert.homelab.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ClientKindLookupTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private ClientKindLookup lookup;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        lookup = new ClientKindLookup(jdbcTemplate);
+    }
+
+    @Test
+    void cacheMissHitsDatabase() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("id-1")))
+                .thenReturn("device");
+
+        assertThat(lookup.lookup("id-1")).isEqualTo("device");
+        assertThat(lookup.isDevice("id-1")).isTrue();
+    }
+
+    @Test
+    void cacheHitSkipsDatabase() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("id-1")))
+                .thenReturn("device");
+
+        lookup.lookup("id-1");
+        lookup.lookup("id-1");
+        lookup.lookup("id-1");
+
+        verify(jdbcTemplate, times(1))
+                .queryForObject(any(String.class), eq(String.class), eq("id-1"));
+    }
+
+    @Test
+    void invalidateForcesRefresh() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("id-1")))
+                .thenReturn("device", "sso");
+
+        assertThat(lookup.lookup("id-1")).isEqualTo("device");
+        lookup.invalidate("id-1");
+        assertThat(lookup.lookup("id-1")).isEqualTo("sso");
+        assertThat(lookup.isDevice("id-1")).isFalse();
+    }
+
+    @Test
+    void unknownIdReturnsNullAndIsNotDevice() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("missing")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThat(lookup.lookup("missing")).isNull();
+        assertThat(lookup.isDevice("missing")).isFalse();
+    }
+
+    @Test
+    void ssoIsNotDevice() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("sso-1")))
+                .thenReturn("sso");
+
+        assertThat(lookup.isDevice("sso-1")).isFalse();
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/service/DeviceClientServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/service/DeviceClientServiceTest.java
@@ -1,0 +1,165 @@
+package ch.furchert.homelab.auth.service;
+
+import ch.furchert.homelab.auth.config.OidcClientProperties;
+import ch.furchert.homelab.auth.dto.DeviceClientCreatedResponse;
+import ch.furchert.homelab.auth.exception.ResourceConflictException;
+import ch.furchert.homelab.auth.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceClientServiceTest {
+
+    @Mock
+    RegisteredClientRepository registeredClientRepository;
+    @Mock
+    JdbcTemplate jdbcTemplate;
+    @Mock
+    PasswordEncoder passwordEncoder;
+    @Mock
+    ClientKindLookup clientKindLookup;
+
+    private OidcClientProperties properties;
+
+    @InjectMocks
+    private DeviceClientService service;
+
+    @BeforeEach
+    void setUp() {
+        properties = new OidcClientProperties();
+        properties.getDeviceClients().setAccessTokenTtlSeconds(3600);
+        properties.getDeviceClients().setAllowedScopes(List.of("mqtt:pub", "mqtt:sub"));
+        service = new DeviceClientService(
+                registeredClientRepository, jdbcTemplate, passwordEncoder, clientKindLookup, properties);
+    }
+
+    @Test
+    void create_returnsPlaintextSecretAndPersistsClientKindDevice() {
+        when(registeredClientRepository.findByClientId("terra1")).thenReturn(null);
+        when(passwordEncoder.encode(any())).thenAnswer(inv -> "{bcrypt}$2a$10$hash-of-" + inv.getArgument(0));
+
+        DeviceClientCreatedResponse response = service.create("terra1", "Greenhouse 1");
+
+        assertThat(response.clientId()).isEqualTo("terra1");
+        assertThat(response.clientSecret()).isNotBlank();
+        // Plaintext secret is base64url-encoded 32 random bytes ~> 43 chars without padding
+        assertThat(response.clientSecret()).hasSizeBetween(40, 45);
+        assertThat(response.scopes()).containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
+        assertThat(response.createdAt()).isNotNull();
+
+        ArgumentCaptor<RegisteredClient> clientCaptor = ArgumentCaptor.forClass(RegisteredClient.class);
+        verify(registeredClientRepository).save(clientCaptor.capture());
+        RegisteredClient saved = clientCaptor.getValue();
+        assertThat(saved.getClientId()).isEqualTo("terra1");
+        assertThat(saved.getClientSecret()).startsWith("{bcrypt}");
+        assertThat(saved.getScopes()).containsExactlyInAnyOrder("mqtt:pub", "mqtt:sub");
+
+        verify(jdbcTemplate).update(
+                "UPDATE oauth2_registered_client SET client_kind = ? WHERE id = ?",
+                "device", saved.getId());
+        verify(clientKindLookup).invalidate(saved.getId());
+    }
+
+    @Test
+    void create_failsFastWhenEncoderOmitsBcryptPrefix() {
+        when(registeredClientRepository.findByClientId("terra1")).thenReturn(null);
+        when(passwordEncoder.encode(any())).thenReturn("missing-prefix-hash");
+
+        assertThatThrownBy(() -> service.create("terra1", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("{bcrypt} prefix");
+
+        verify(registeredClientRepository, never()).save(any());
+        verify(jdbcTemplate, never()).update(any(String.class), any(), any());
+    }
+
+    @Test
+    void create_rejectsDuplicateClientId() {
+        RegisteredClient existing = RegisteredClient.withId("x").clientId("terra1")
+                .clientSecret("{noop}s").clientAuthenticationMethod(
+                        org.springframework.security.oauth2.core.ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(org.springframework.security.oauth2.core.AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .build();
+        when(registeredClientRepository.findByClientId("terra1")).thenReturn(existing);
+
+        assertThatThrownBy(() -> service.create("terra1", null))
+                .isInstanceOf(ResourceConflictException.class);
+
+        verify(registeredClientRepository, never()).save(any());
+    }
+
+    @Test
+    void delete_isIdempotentWhenMissing() {
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("ghost"), eq("device")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        service.delete("ghost");
+
+        verify(jdbcTemplate, never()).update(any(String.class), eq("ghost"));
+    }
+
+    @Test
+    void delete_doesNotTouchSsoClient() {
+        // SELECT returns no row because the client_kind='device' filter excludes the SSO row.
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("grafana"), eq("device")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        service.delete("grafana");
+
+        // CRITICAL: no DELETE FROM oauth2_authorization is issued for the SSO client.
+        verify(jdbcTemplate, never()).update(
+                eq("DELETE FROM oauth2_authorization WHERE registered_client_id = ?"),
+                any(Object[].class));
+        verify(jdbcTemplate, never()).update(
+                eq("DELETE FROM oauth2_authorization_consent WHERE registered_client_id = ?"),
+                any(Object[].class));
+        verify(jdbcTemplate, never()).update(
+                eq("DELETE FROM oauth2_registered_client WHERE id = ?"),
+                any(Object[].class));
+    }
+
+    @Test
+    void delete_revokesAuthorizationsAndDeletesRowForDeviceClient() {
+        String internalId = "uuid-1";
+        when(jdbcTemplate.queryForObject(any(String.class), eq(String.class), eq("terra1"), eq("device")))
+                .thenReturn(internalId);
+
+        service.delete("terra1");
+
+        verify(jdbcTemplate).update(
+                "DELETE FROM oauth2_authorization WHERE registered_client_id = ?", internalId);
+        verify(jdbcTemplate).update(
+                "DELETE FROM oauth2_authorization_consent WHERE registered_client_id = ?", internalId);
+        verify(jdbcTemplate).update(
+                "DELETE FROM oauth2_registered_client WHERE id = ?", internalId);
+        verify(clientKindLookup).invalidate(internalId);
+    }
+
+    @Test
+    void get_unknownClient_throws404() {
+        when(jdbcTemplate.queryForObject(any(String.class), any(org.springframework.jdbc.core.RowMapper.class),
+                eq("device"), eq("ghost")))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThatThrownBy(() -> service.get("ghost"))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/src/test/java/ch/furchert/homelab/auth/service/UserServiceTest.java
+++ b/src/test/java/ch/furchert/homelab/auth/service/UserServiceTest.java
@@ -4,8 +4,8 @@ import ch.furchert.homelab.auth.dto.CreateUserRequest;
 import ch.furchert.homelab.auth.dto.ResetPasswordRequest;
 import ch.furchert.homelab.auth.dto.UpdateUserRequest;
 import ch.furchert.homelab.auth.dto.UserResponse;
-import ch.furchert.homelab.auth.entity.User;
 import ch.furchert.homelab.auth.entity.Role;
+import ch.furchert.homelab.auth.entity.User;
 import ch.furchert.homelab.auth.exception.ResourceNotFoundException;
 import ch.furchert.homelab.auth.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {


### PR DESCRIPTION
This pull request adds important documentation and feedback entries to the project memory, focusing on recent decisions and technical gotchas for Spring Security and JWT handling. The main update documents the implementation and shipment of IoT Device OAuth2 Clients, including backend changes, admin API, and operational impacts. Two new feedback notes clarify critical behaviors in Spring Security method security and JWT `scope` claim handling.

**Project milestone and implementation:**

* [`.claude/memory/MEMORY.md`](diffhunk://#diff-8d7d95801d42d7e808975d3ba9381a7c84adc2f2bcbfd8c5e9a336f16828bff1R5-R29): Added a detailed entry for the implementation and shipment of IoT Device OAuth2 Clients, describing the migration to JDBC-backed `RegisteredClientRepository`, new admin API endpoints, JWT claim changes, caching, and operational notes. Also summarizes blockers found and fixed before commit, and outlines follow-up tasks and documentation updates.

**Spring Security and JWT feedback:**

* [`.claude/memory/feedback_method_security_required.md`](diffhunk://#diff-5ae418bd4c518c59a455292a6c726b7b6b836055c4f1b878ca966192805f517eR1-R17): Added a feedback note explaining that `@PreAuthorize` is ignored unless `@EnableMethodSecurity` is present, and that `AuthorizationDeniedException` must be explicitly mapped to a 403 response. Includes guidance for proper configuration and testing.
* [`.claude/memory/feedback_ss7_jwt_scope_shape.md`](diffhunk://#diff-811fea1840bf3c2a3fd3253ca48951c5cd0a61b66623d25e9127c8db56189ba4R1-R24): Added a feedback note documenting that Spring Authorization Server 7 serializes the JWT `scope` claim as a JSON array (while the token endpoint uses a space-separated string), and provides advice for writing compatible tests.