### PR TITLE
fix(db): revert formatter whitespace on applied migrations V1-V3

### DIFF
--- a/src/main/resources/db/migration/V2__timestamps_to_timestamptz_and_fixes.sql
+++ b/src/main/resources/db/migration/V2__timestamps_to_timestamptz_and_fixes.sql
@@ -1,5 +1,4 @@
-SET
-timezone = 'UTC';
+SET timezone = 'UTC';
 
 -- Convert all timestamp columns to timestamptz for correct timezone handling
 ALTER TABLE users ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';


### PR DESCRIPTION
An IDE SQL formatter reflowed already-applied migrations (8794aa1), changing their Flyway checksums and breaking startup validation (checksum mismatch on V2). SQL is semantically unchanged; restoring the original bytes realigns the checksums with flyway_schema_history_auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor maintenance update to a database migration file. No functional behavior or user-facing changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->